### PR TITLE
ISSUE-12 Migrating settings to Map<String, Object>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ Changelog
 
 * Updated to CoreMedia Content Cloud 10.2004.
 
-* Updated ```ActionTestBaseConfiguration``` to latest version of the ```TranslatablePredicate``` interface.
+* Updated `ActionTestBaseConfiguration` to latest version of the 
+  `TranslatablePredicate` interface.
 
-* Removed ```translatableExpressions``` configuration from  
-  ```TranslateGccConfiguration``` which is now provided by the Blueprint's 
+* Removed `translatableExpressions` configuration from  
+  `TranslateGccConfiguration` which is now provided by the Blueprint's 
   multi-site module.
   
 2001

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Changelog
   `TranslateGccConfiguration` which is now provided by the Blueprint's 
   multi-site module.
   
+* Fixed ISSUE-12 to allow the usage of other setting types within the facade. 
+
+  The interfaces of `GCExchangeFacadeProvider`, `GCExchangeFacadeSessionProvide`
+  and all its subclasses have been updated to pass `Map<String, Object>` instead
+  of `Map<String, String>`. If you have customized these classes or created your
+  own subclasses, you will have to update them and make sure to cast the value
+  of the settings in your implementation accordingly.
+  
 2001
 --------------------------------------------------------------------------------
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
@@ -96,7 +96,7 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
    * @throws GCFacadeConfigException        if configuration is incomplete
    * @throws GCFacadeCommunicationException if connection to GCC failed.
    */
-  DefaultGCExchangeFacade(Map<String, String> config) {
+  DefaultGCExchangeFacade(Map<String, Object> config) {
     String apiUrl = requireNonNullConfig(config, GCConfigProperty.KEY_URL);
     String userName = requireNonNullConfig(config, GCConfigProperty.KEY_USERNAME);
     String password = requireNonNullConfig(config, GCConfigProperty.KEY_PASSWORD);
@@ -113,7 +113,9 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
     } catch (RuntimeException e) {
       throw new GCFacadeCommunicationException(e, "Failed to connect to GCC at %s.", apiUrl);
     }
-    this.fileTypeSupplier = Suppliers.memoize(() -> getSupportedFileType(config.get(GCConfigProperty.KEY_FILE_TYPE)));
+    this.fileTypeSupplier = Suppliers.memoize(() -> getSupportedFileType(
+            String.valueOf(config.get(GCConfigProperty.KEY_FILE_TYPE)))
+    );
   }
 
   @VisibleForTesting
@@ -122,14 +124,14 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
     this.fileTypeSupplier = () -> fileType;
   }
 
-  private static <T> T requireNonNullConfig(Map<?, T> config, Object key) {
-    T value = config.get(key);
+  private static String requireNonNullConfig(Map<String, Object> config, String key) {
+    Object value = config.get(key);
     if (value == null) {
       throw new GCFacadeConfigException("Configuration for %s is missing. Configuration (values hidden): %s", key, config.entrySet().stream()
               .collect(toMap(Map.Entry::getKey, e -> GCConfigProperty.KEY_URL.equals(e.getKey()) ? e.getValue() : "*****"))
       );
     }
-    return value;
+    return String.valueOf(value);
   }
 
   /**

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeProvider.java
@@ -22,7 +22,7 @@ public class DefaultGCExchangeFacadeProvider implements GCExchangeFacadeProvider
   }
 
   @Override
-  public GCExchangeFacade getFacade(Map<String, String> settings) {
+  public GCExchangeFacade getFacade(Map<String, Object> settings) {
     return new DefaultGCExchangeFacade(settings);
   }
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
@@ -95,7 +95,7 @@ class DefaultGCExchangeFacadeContractTest {
 
   @Test
   @DisplayName("Validate that login works.")
-  void login(Map<String, String> gccProperties) {
+  void login(Map<String, Object> gccProperties) {
     LOG.info("Properties: {}", gccProperties);
     try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
       assertThat(facade.getDelegate()).isNotNull();
@@ -108,7 +108,7 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest(name = "[{index}] Optional File Type {0} should be available.")
     @ValueSource(strings = {"xml"})
     @DisplayName("Ensure that optional file types are available.")
-    void optionalFileTypesAvailable(String type, Map<String, String> gccProperties) {
+    void optionalFileTypesAvailable(String type, Map<String, Object> gccProperties) {
       // These file types are optional. They may be required for testing, but they are not
       // important for production usage.
       assertFileTypeAvailable(type, gccProperties);
@@ -117,12 +117,12 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest(name = "[{index}] Required File Type {0} should be available.")
     @ValueSource(strings = {"xliff"})
     @DisplayName("Ensure that required file types are available.")
-    void requiredFileTypesAvailable(String type, Map<String, String> gccProperties) {
+    void requiredFileTypesAvailable(String type, Map<String, Object> gccProperties) {
       // These file types are crucial for this GCC client.
       assertFileTypeAvailable(type, gccProperties);
     }
 
-    private void assertFileTypeAvailable(String type, Map<String, String> gccProperties) {
+    private void assertFileTypeAvailable(String type, Map<String, Object> gccProperties) {
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
         GCExchange delegate = facade.getDelegate();
         ConnectorsConfig.ConnectorsConfigResponseData connectorsConfig = delegate.getConnectorsConfig();
@@ -138,18 +138,18 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest(name = "[{index}] Required Target Locale {0} should be available.")
     @ValueSource(strings = {"de-DE", "fr-FR"})
     @DisplayName("Ensure that target locales required by tests are available.")
-    void requiredTargetLocalesAreAvailable(String expectedSupportedLocale, Map<String, String> gccProperties) {
+    void requiredTargetLocalesAreAvailable(String expectedSupportedLocale, Map<String, Object> gccProperties) {
       assertSupportedLocaleAvailable(expectedSupportedLocale, lc -> !lc.getIsSource(), gccProperties);
     }
 
     @ParameterizedTest(name = "[{index}] Required Source Locale {0} should be available.")
     @ValueSource(strings = {"en-US"})
     @DisplayName("Ensure that source locales required by tests are available.")
-    void requiredSourceLocalesAreAvailable(String expectedSupportedLocale, Map<String, String> gccProperties) {
+    void requiredSourceLocalesAreAvailable(String expectedSupportedLocale, Map<String, Object> gccProperties) {
       assertSupportedLocaleAvailable(expectedSupportedLocale, LocaleConfig::getIsSource, gccProperties);
     }
 
-    private void assertSupportedLocaleAvailable(String expectedSupportedLocale, Predicate<LocaleConfig> localeConfigPredicate, Map<String, String> gccProperties) {
+    private void assertSupportedLocaleAvailable(String expectedSupportedLocale, Predicate<LocaleConfig> localeConfigPredicate, Map<String, Object> gccProperties) {
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
         ConnectorsConfig.ConnectorsConfigResponseData connectorsConfig = facade.getDelegate().getConnectorsConfig();
         List<Locale> supportedLocales = getSupportedLocaleStream(connectorsConfig, localeConfigPredicate).collect(Collectors.toList());
@@ -165,7 +165,7 @@ class DefaultGCExchangeFacadeContractTest {
   class ContentUpload {
     @Test
     @DisplayName("Upload File.")
-    void upload(TestInfo testInfo, Map<String, String> gccProperties) {
+    void upload(TestInfo testInfo, Map<String, Object> gccProperties) {
       Instant startTimeUtc = Instant.now().atZone(ZoneOffset.UTC).toInstant();
       String fileName = testInfo.getDisplayName();
 
@@ -212,7 +212,7 @@ class DefaultGCExchangeFacadeContractTest {
   class Cancellation {
     @Test
     @DisplayName("Be aware of submission/task cancellation.")
-    void shouldBeCancellationAware(TestInfo testInfo, Map<String, String> gccProperties) {
+    void shouldBeCancellationAware(TestInfo testInfo, Map<String, Object> gccProperties) {
       String testName = testInfo.getDisplayName();
 
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
@@ -280,7 +280,7 @@ class DefaultGCExchangeFacadeContractTest {
   class ContentSubmission {
     @Test
     @DisplayName("Test simple submission")
-    void submitXml(TestInfo testInfo, Map<String, String> gccProperties) {
+    void submitXml(TestInfo testInfo, Map<String, Object> gccProperties) {
       String testName = testInfo.getDisplayName();
 
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
@@ -306,7 +306,7 @@ class DefaultGCExchangeFacadeContractTest {
 
     @Test
     @DisplayName("Tests dealing with submission name length restrictions (currently 150 chars): Mode: ASCII, skip additional information")
-    void submissionNameTruncationAsciiSkipAdditionalInfo(TestInfo testInfo, Map<String, String> gccProperties) {
+    void submissionNameTruncationAsciiSkipAdditionalInfo(TestInfo testInfo, Map<String, Object> gccProperties) {
       String testName = testInfo.getDisplayName();
       String submissionName = padEnd(testName, 150, 'a', 'z');
 
@@ -325,7 +325,7 @@ class DefaultGCExchangeFacadeContractTest {
 
     @Test
     @DisplayName("Tests dealing with submission name length restrictions (currently 150 chars): Mode: ASCII, subject truncation")
-    void submissionNameTruncationAscii(TestInfo testInfo, Map<String, String> gccProperties) {
+    void submissionNameTruncationAscii(TestInfo testInfo, Map<String, Object> gccProperties) {
       String testName = testInfo.getDisplayName();
       String submissionName = padEnd(testName, 200, 'a', 'z');
 
@@ -344,7 +344,7 @@ class DefaultGCExchangeFacadeContractTest {
 
     @Test
     @DisplayName("Tests dealing with submission name length restrictions (currently 150 chars): Mode: Unicode, skip additional information")
-    void submissionNameTruncationUnicode(TestInfo testInfo, Map<String, String> gccProperties) {
+    void submissionNameTruncationUnicode(TestInfo testInfo, Map<String, Object> gccProperties) {
       String testName = testInfo.getDisplayName();
       // 2190..21FF Arrows
       String submissionName = padEnd(testName, 150, '\u2190', '\u21FF');
@@ -390,7 +390,7 @@ class DefaultGCExchangeFacadeContractTest {
   @Tag("slow")
   @Tag("full")
   @DisplayName("Translate XLIFF and receive results (takes about 10 Minutes)")
-  void translateXliff(TestInfo testInfo, Map<String, String> gccProperties) {
+  void translateXliff(TestInfo testInfo, Map<String, Object> gccProperties) {
     String testName = testInfo.getDisplayName();
 
     try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
@@ -97,7 +97,7 @@ class DefaultGCExchangeFacadeTest {
           GCConfigProperty.KEY_KEY
   })
   void failOnMissingRequiredConfiguration(String excludedKey) {
-    Map<String, String> config = new HashMap<>();
+    Map<String, Object> config = new HashMap<>();
     List<String> requiredKeys = new ArrayList<>(asList(
             GCConfigProperty.KEY_URL,
             GCConfigProperty.KEY_USERNAME,

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacadeProvider.java
@@ -17,7 +17,7 @@ public class DisabledGCExchangeFacadeProvider implements GCExchangeFacadeProvide
   }
 
   @Override
-  public GCExchangeFacade getFacade(Map<String, String> settings) {
+  public GCExchangeFacade getFacade(Map<String, Object> settings) {
     return DisabledGCExchangeFacade.getInstance();
   }
 }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockGCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockGCExchangeFacadeProvider.java
@@ -28,18 +28,18 @@ public class MockGCExchangeFacadeProvider implements GCExchangeFacadeProvider {
   }
 
   @Override
-  public GCExchangeFacade getFacade(Map<String, String> settings) {
+  public GCExchangeFacade getFacade(Map<String, Object> settings) {
     MockedGCExchangeFacade facade = new MockedGCExchangeFacade();
 
-    String delaySeconds = settings.get(CONFIG_DELAY_SECONDS);
+    String delaySeconds = String.valueOf(settings.get(CONFIG_DELAY_SECONDS));
     if (delaySeconds != null) {
       facade.setDelayBaseSeconds(Long.parseLong(delaySeconds));
     }
-    String delayOffsetPercentage = settings.get(CONFIG_DELAY_OFFSET_PERCENTAGE);
+    String delayOffsetPercentage = String.valueOf(settings.get(CONFIG_DELAY_OFFSET_PERCENTAGE));
     if (delayOffsetPercentage != null) {
       facade.setDelayOffsetPercentage(Integer.parseInt(delayOffsetPercentage));
     }
-    String mockError = settings.get(CONFIG_MOCK_ERROR);
+    String mockError = String.valueOf(settings.get(CONFIG_MOCK_ERROR));
     Arrays.stream(MockError.values())
             .filter(e -> e.toString().equalsIgnoreCase(mockError))
             .findAny()

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/DefaultGCExchangeFacadeSessionProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/DefaultGCExchangeFacadeSessionProvider.java
@@ -33,8 +33,8 @@ public final class DefaultGCExchangeFacadeSessionProvider implements GCExchangeF
    * facade to instantiate.
    */
   @Override
-  public GCExchangeFacade openSession(Map<String, String> settings) {
-    String facadeType = settings.getOrDefault(GCConfigProperty.KEY_TYPE, GCConfigProperty.VALUE_TYPE_DEFAULT);
+  public GCExchangeFacade openSession(Map<String, Object> settings) {
+    String facadeType = String.valueOf(settings.getOrDefault(GCConfigProperty.KEY_TYPE, GCConfigProperty.VALUE_TYPE_DEFAULT));
     LOG.debug("Identified facade type to use: {}", facadeType);
     GCExchangeFacadeProvider defaultFacadeProvider = null;
     for (GCExchangeFacadeProvider facadeProvider : facadeProviders) {

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeProvider.java
@@ -34,7 +34,7 @@ public interface GCExchangeFacadeProvider {
    * @param settings settings to use, contains for example credentials
    * @return GCExchange facade
    */
-  GCExchangeFacade getFacade(Map<String, String> settings);
+  GCExchangeFacade getFacade(Map<String, Object> settings);
 
   /**
    * Signal, if this is a default SPI, which should be used if no other SPI

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeSessionProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeSessionProvider.java
@@ -27,5 +27,5 @@ public interface GCExchangeFacadeSessionProvider {
    * @implSpec Factories may support extra settings in order to control which
    * facade to instantiate.
    */
-  GCExchangeFacade openSession(Map<String, String> settings);
+  GCExchangeFacade openSession(Map<String, Object> settings);
 }

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
@@ -373,8 +373,8 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   }
 
   private int maxAutomaticRetries(Site masterSite) {
-    Map<String, String> gccSettings = getGccSettings(masterSite);
-    String value = gccSettings.get(CONFIG_RETRY_COMMUNICATION_ERRORS);
+    Map<String, Object> gccSettings = getGccSettings(masterSite);
+    String value = String.valueOf(gccSettings.get(CONFIG_RETRY_COMMUNICATION_ERRORS));
     if (value != null) {
       try {
         return Integer.parseInt(value);
@@ -386,10 +386,10 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   }
 
   @VisibleForTesting
-  Map<String, String> getGccSettings(Site site) {
+  Map<String, Object> getGccSettings(Site site) {
     Content siteIndicator = site.getSiteIndicator();
 
-    Map<String, String> siteIndicatorSettings = getGccSettings(siteIndicator);
+    Map<String, Object> siteIndicatorSettings = getGccSettings(siteIndicator);
     if (!siteIndicatorSettings.isEmpty()) {
       return siteIndicatorSettings;
     }
@@ -398,7 +398,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
     return getGccSettings(siteRootDocument);
   }
 
-  private static Map<String, String> getGccSettings(Content content) {
+  private static Map<String, Object> getGccSettings(Content content) {
     Struct localSettings = getStruct(content, LOCAL_SETTINGS);
     Struct struct = StructUtil.mergeStructList(
             localSettings,
@@ -410,10 +410,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
     if (struct != null) {
       Object value = struct.get(GCConfigProperty.KEY_GLOBALLINK_ROOT);
       if (value instanceof Struct) {
-        return ((Struct) value).toNestedMaps()
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
+        return ((Struct) value).toNestedMaps();
       }
     }
 

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkActionTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkActionTest.java
@@ -97,7 +97,7 @@ class GlobalLinkActionTest {
     }
 
     @Override
-    protected Map<String, String> getGccSettings(Site site) {
+    protected Map<String, Object> getGccSettings(Site site) {
       return ImmutableMap.of(
               GCConfigProperty.KEY_URL, "http://lorem.ipsum.fun/",
               GCConfigProperty.KEY_USERNAME, "Horst",


### PR DESCRIPTION
API change first. Existing settings remain strings to minimize migration efforts. New settings should however be properly typed.