### PR TITLE
Send instructions, workflow and submitter in the submission, fixes #26

### DIFF
--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
@@ -167,7 +167,7 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public long submitSubmission(@Nullable String subject, ZonedDateTime dueDate, Locale sourceLocale, Map<String, List<Locale>> contentMap) {
+  public long submitSubmission(@Nullable String subject, String comment, ZonedDateTime dueDate, String workflow, String submitter, Locale sourceLocale, Map<String, List<Locale>> contentMap) {
 
     List<ContentLocales> contentLocalesList = contentMap.entrySet().stream()
             .map(e ->
@@ -182,6 +182,9 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
             sourceLocale.toLanguageTag(),
             contentLocalesList
     );
+    request.setInstructions(comment);
+    request.setWorkflow(workflow);
+    request.setSubmitter(submitter);
 
     try {
       SubmissionSubmit.SubmissionSubmitResponseData response = delegate.submitSubmission(request);

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
@@ -221,7 +221,10 @@ class DefaultGCExchangeFacadeContractTest {
         String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
         long submissionId = facade.submitSubmission(
                 testName,
+                null,
                 ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+                null,
+                "admin",
                 Locale.US,
                 singletonMap(fileId, singletonList(Locale.GERMANY))
         );
@@ -287,7 +290,10 @@ class DefaultGCExchangeFacadeContractTest {
         String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
         long submissionId = facade.submitSubmission(
                 testName,
+                null,
                 ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+                null,
+                "admin",
                 Locale.US,
                 singletonMap(fileId, singletonList(Locale.GERMANY))
         );
@@ -314,7 +320,10 @@ class DefaultGCExchangeFacadeContractTest {
         String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
         long submissionId = facade.submitSubmission(
                 submissionName,
+                null,
                 ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+                null,
+                "admin",
                 Locale.US,
                 singletonMap(fileId, singletonList(Locale.GERMANY))
         );
@@ -333,7 +342,10 @@ class DefaultGCExchangeFacadeContractTest {
         String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
         long submissionId = facade.submitSubmission(
                 submissionName,
+                null,
                 ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+                null,
+                "admin",
                 Locale.US,
                 singletonMap(fileId, singletonList(Locale.GERMANY))
         );
@@ -353,7 +365,10 @@ class DefaultGCExchangeFacadeContractTest {
         String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
         long submissionId = facade.submitSubmission(
                 submissionName,
+                null,
                 ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+                null,
+                "admin",
                 Locale.US,
                 singletonMap(fileId, singletonList(Locale.GERMANY))
         );
@@ -407,7 +422,10 @@ class DefaultGCExchangeFacadeContractTest {
       Map<String, List<Locale>> contentMap = uploadContents(facade, testName, masterLocale, targetLocales);
       long submissionId = facade.submitSubmission(
               testName,
+              null,
               ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+              null,
+              "admin",
               masterLocale,
               contentMap
       );

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
@@ -182,9 +182,12 @@ class DefaultGCExchangeFacadeTest {
     @DisplayName("Test for successful submission.")
     void happyPath(TestInfo testInfo) {
       String subject = testInfo.getDisplayName();
+      String comment = "Test";
       LocalDateTime dueDateLocal = LocalDateTime.now().plusHours(2);
       ZoneOffset zoneOffset = ZoneOffset.ofHoursMinutesSeconds(1, 2, 3);
       ZonedDateTime dueDate = ZonedDateTime.of(dueDateLocal, zoneOffset);
+      String workflow = "pseudo translation";
+      String submitter = "admin";
       Date expectedUtcDueDate = Date.from(dueDateLocal.atOffset(zoneOffset).toInstant());
       Locale sourceLocale = Locale.US;
       Locale targetLocale = Locale.FRANCE;
@@ -196,7 +199,7 @@ class DefaultGCExchangeFacadeTest {
       when(response.getSubmissionId()).thenReturn(expectedSubmissionId);
 
       try (GCExchangeFacade facade = new MockDefaultGCExchangeFacade(gcExchange)) {
-        long submissionId = facade.submitSubmission(subject, dueDate, sourceLocale, singletonMap(fileId, singletonList(targetLocale)));
+        long submissionId = facade.submitSubmission(subject, comment, dueDate, workflow, submitter, sourceLocale, singletonMap(fileId, singletonList(targetLocale)));
 
         assertThat(submissionId).isEqualTo(expectedSubmissionId);
         verify(gcExchange).submitSubmission(submissionSubmitRequestCaptor.capture());
@@ -215,9 +218,12 @@ class DefaultGCExchangeFacadeTest {
     @DisplayName("Correctly deal with communication errors.")
     void dealWithCommunicationExceptions(TestInfo testInfo) {
       String subject = testInfo.getDisplayName();
+      String comment = "Test";
       LocalDateTime dueDateLocal = LocalDateTime.now().plusHours(2);
       ZoneOffset zoneOffset = ZoneOffset.ofHoursMinutesSeconds(1, 2, 3);
       ZonedDateTime dueDate = ZonedDateTime.of(dueDateLocal, zoneOffset);
+      String workflow = "pseudo translation";
+      String submitter = "admin";
       Locale sourceLocale = Locale.US;
       Locale targetLocale = Locale.FRANCE;
       String fileId = "1234-5678";
@@ -225,7 +231,7 @@ class DefaultGCExchangeFacadeTest {
       when(gcExchange.submitSubmission(any())).thenThrow(RuntimeException.class);
 
       try (GCExchangeFacade facade = new MockDefaultGCExchangeFacade(gcExchange)) {
-        assertThatThrownBy(() -> facade.submitSubmission(subject, dueDate, sourceLocale, singletonMap(fileId, singletonList(targetLocale))))
+        assertThatThrownBy(() -> facade.submitSubmission(subject, comment, dueDate, workflow, submitter, sourceLocale, singletonMap(fileId, singletonList(targetLocale))))
                 .isInstanceOf(GCFacadeCommunicationException.class)
                 .hasCauseInstanceOf(RuntimeException.class)
                 .hasMessageContaining(subject)

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
@@ -64,7 +64,7 @@ public final class DisabledGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public long submitSubmission(String subject, ZonedDateTime dueDate, Locale sourceLocale, Map<String, List<Locale>> contentMap) {
+  public long submitSubmission(String subject, String comment, ZonedDateTime dueDate, String workflow, String submitter, Locale sourceLocale, Map<String, List<Locale>> contentMap) {
     throw createDisabledException();
   }
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
@@ -104,7 +104,7 @@ public final class MockedGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public long submitSubmission(String subject, ZonedDateTime dueDate, Locale sourceLocale, Map<String, List<Locale>> contentMap) {
+  public long submitSubmission(String subject, String comment, ZonedDateTime dueDate, String workflow, String submitter, Locale sourceLocale, Map<String, List<Locale>> contentMap) {
     List<SubmissionContent> collect = contentMap.entrySet().stream()
             .map(e -> new SubmissionContent(
                     e.getKey(),

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/test/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/test/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacadeTest.java
@@ -52,7 +52,10 @@ class MockedGCExchangeFacadeTest {
       String fileId = facade.uploadContent(testName, xliffResource);
       long submissionId = facade.submitSubmission(
               testName,
+              null,
               ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+              null,
+              "admin",
               Locale.US,
               singletonMap(fileId, singletonList(Locale.ROOT))
       );
@@ -111,7 +114,10 @@ class MockedGCExchangeFacadeTest {
       String fileId = facade.uploadContent(testName, xliffResource);
       long submissionId = facade.submitSubmission(
               "states:other,cancelled",
+              null,
               ZonedDateTime.of(LocalDateTime.now().plusHours(2), ZoneId.systemDefault()),
+              null,
+              "admin",
               Locale.US,
               singletonMap(fileId, singletonList(Locale.ROOT))
       );

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
@@ -38,7 +38,7 @@ public interface GCExchangeFacade extends AutoCloseable {
 
   /**
    * Uploads the given content, like for example an XLIFF file. Returns
-   * the file ID which is later required in {@link #submitSubmission(String, ZonedDateTime, Locale, Map)}.
+   * the file ID which is later required in {@link #submitSubmission(String, String, ZonedDateTime, String, String, Locale, Map)}.
    *
    * @param fileName the filename of the resource
    * @param resource the resource to send
@@ -52,7 +52,10 @@ public interface GCExchangeFacade extends AutoCloseable {
    * Submit submission for the given contents uploaded before.
    *
    * @param subject      workflow subject
+   * @param comment      instructions for translators
    * @param dueDate      due date for the submission; implies the priority when translation jobs should be done
+   * @param workflow     translation workflow to be used, if not the default
+   * @param submitter    name of the submitter
    * @param sourceLocale source locale
    * @param contentMap   file IDs (returned by {@link #uploadContent(String, Resource)}) to translate
    *                     with the desired target locales to translate to
@@ -60,7 +63,7 @@ public interface GCExchangeFacade extends AutoCloseable {
    * @throws GCFacadeCommunicationException if submitting the submission failed
    * @see #uploadContent(String, Resource)
    */
-  long submitSubmission(String subject, ZonedDateTime dueDate, Locale sourceLocale, Map<String, List<Locale>> contentMap);
+  long submitSubmission(String subject, String comment, ZonedDateTime dueDate, String workflow, String submitter, Locale sourceLocale, Map<String, List<Locale>> contentMap);
 
   /**
    * Cancel a submission.

--- a/apps/workflow-server/gcc-workflow-server/src/main/resources/com/coremedia/labs/translation/gcc/workflow/translation-global-link.xml
+++ b/apps/workflow-server/gcc-workflow-server/src/main/resources/com/coremedia/labs/translation/gcc/workflow/translation-global-link.xml
@@ -84,6 +84,8 @@
     <Variable name="globalLinkSubmissionStatus" type="String"/>
     <!-- Date that represents dueDate for the globalLink API -->
     <Variable name="globalLinkDueDate" type="Date"/>
+    <!-- Which translation workflow is used for the submission, if not the default -->
+    <Variable name="workflow" type="String"/>
     <!-- set to true if the editor requested cancellation of the translation request -->
     <Variable name="cancelRequested" type="Boolean"><Boolean value="false"/></Variable>
     <!-- set to true after a cancellation request was sent to the translation service -->
@@ -97,6 +99,7 @@
       <Writes variable="masterContentObjects"/>
       <Writes variable="targetSiteId"/>
       <Writes variable="globalLinkDueDate"/>
+      <Writes variable="workflow"/>
       <Writes variable="cancellationAllowed"/>
       <Writes variable="placeholderPreparationStrategy"/>
     </InitialAssignment>
@@ -111,6 +114,7 @@
       <Writes variable="globalLinkSubmissionId"/>
       <Writes variable="globalLinkSubmissionStatus"/>
       <Writes variable="globalLinkDueDate"/>
+      <Writes variable="workflow"/>
       <Writes variable="workflowActionIssues"/>
       <Writes variable="remainingAutomaticRetries"/>
       <Writes variable="cancelRequested"/>
@@ -177,11 +181,13 @@
       </Guard>
       <Action class="com.coremedia.labs.translation.gcc.workflow.SendToGlobalLinkAction"
               subjectVariable="subject"
+              commentVariable="comment"
               derivedContentsVariable="derivedContents"
               masterContentObjectsVariable="masterContentObjects"
               issuesVariable="workflowActionIssues"
               resultVariable="globalLinkSubmissionId"
               globalLinkDueDateVariable="globalLinkDueDate"
+              workflowVariable="workflow"
               remainingAutomaticRetriesVariable="remainingAutomaticRetries"/>
       <!-- wait 180 seconds before retrying in case of error -->
       <Action class="AssignVariable" resultVariable="sendTranslationRequestRetryDelay"><Timer value="180"/></Action>

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkActionTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkActionTest.java
@@ -96,11 +96,14 @@ class SendToGlobalLinkActionTest {
             .when(gcExchangeFacade)
             .uploadContent(anyString(), any(Resource.class));
 
-    Mockito.doReturn(expectedSubmissionId).when(gcExchangeFacade).submitSubmission(anyString(), any(ZonedDateTime.class), any(Locale.class), anyMap());
+    Mockito.doReturn(expectedSubmissionId).when(gcExchangeFacade).submitSubmission(anyString(), anyString(), any(ZonedDateTime.class), anyString(), anyString(), any(Locale.class), anyMap());
 
     List<Content> derivedContents = singletonList(targetContent);
+    String comment = "Test";
     ZonedDateTime dueDate = ZonedDateTime.of(LocalDateTime.now().plusDays(30), ZoneId.systemDefault());
-    SendToGlobalLinkAction.Parameters params = new SendToGlobalLinkAction.Parameters(displayName, derivedContents, masterContents, dueDate);
+    String workflow = "pseudo translation";
+    String submitter = "admin";
+    SendToGlobalLinkAction.Parameters params = new SendToGlobalLinkAction.Parameters(displayName, comment, derivedContents, masterContents, dueDate, workflow, submitter);
     AtomicReference<String> resultHolder = new AtomicReference<>();
     action.doExecuteGlobalLinkAction(params, resultHolder::set, gcExchangeFacade, new HashMap<>());
     String submissionId = resultHolder.get();
@@ -109,7 +112,7 @@ class SendToGlobalLinkActionTest {
     ArgumentCaptor<Locale> masterLocaleCaptor = ArgumentCaptor.forClass(Locale.class);
 
     Mockito.verify(gcExchangeFacade).uploadContent(anyString(), any(Resource.class));
-    Mockito.verify(gcExchangeFacade).submitSubmission(anyString(), any(ZonedDateTime.class), masterLocaleCaptor.capture(), contentMapCaptor.capture());
+    Mockito.verify(gcExchangeFacade).submitSubmission(anyString(), anyString(), any(ZonedDateTime.class), anyString(), anyString(), masterLocaleCaptor.capture(), contentMapCaptor.capture());
 
     assertThat(uploadedXliff[0])
             .describedAs("XLIFF shall contain all relevant information.")


### PR DESCRIPTION
Based on a discussion with Eduardo Aguilera from TransPerfect side, they would like that the submitter (user who started the workflow) is sent in the submission, and also any instructions for the translators (from the notes of the workflow). This patch also allows customizing the workflow (on GlobalLink side) more easily, if it is required (e.g. to specify MTPE or raw MT to be used for a particular submission). By default the workflow is sent as null.

The SendToGlobalLinkAction should be backwards compatible with older workflows where the commentVariable or workflowVariable is not set.