### PR TITLE
Send source locale in file upload call

### DIFF
--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
@@ -152,7 +152,7 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public String uploadContent(String fileName, Resource resource) {
+  public String uploadContent(String fileName, Resource resource, Locale sourceLocale) {
     byte[] bytes;
     try (InputStream stream = resource.getInputStream()) {
       bytes = ByteStreams.toByteArray(stream);
@@ -161,6 +161,9 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
     }
     try {
       UploadFileRequest request = new UploadFileRequest(bytes, fileName, fileTypeSupplier.get());
+      if (sourceLocale != null) {
+        request.setSourceLocale(sourceLocale.toLanguageTag());
+      }
       return delegate.uploadContent(request);
     } catch (GCFacadeException e) {
       throw e;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
@@ -173,7 +173,7 @@ class DefaultGCExchangeFacadeContractTest {
         GCExchange delegate = facade.getDelegate();
 
         long contentCountBefore = getTotalRecordsCount(delegate);
-        String fileId = facade.uploadContent(fileName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
+        String fileId = facade.uploadContent(fileName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)), null);
 
         assertThat(fileId).isNotEmpty();
 
@@ -218,7 +218,7 @@ class DefaultGCExchangeFacadeContractTest {
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
         GCExchange delegate = facade.getDelegate();
 
-        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
+        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)), null);
         long submissionId = facade.submitSubmission(
                 testName,
                 null,
@@ -285,7 +285,7 @@ class DefaultGCExchangeFacadeContractTest {
       String testName = testInfo.getDisplayName();
 
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
-        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
+        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)), null);
         long submissionId = facade.submitSubmission(
                 testName,
                 null,
@@ -313,7 +313,7 @@ class DefaultGCExchangeFacadeContractTest {
       String submissionName = padEnd(testName, 150, 'a', 'z');
 
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
-        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
+        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)), null);
         long submissionId = facade.submitSubmission(
                 submissionName,
                 null,
@@ -333,7 +333,7 @@ class DefaultGCExchangeFacadeContractTest {
       String submissionName = padEnd(testName, 200, 'a', 'z');
 
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
-        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
+        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)), null);
         long submissionId = facade.submitSubmission(
                 submissionName,
                 null,
@@ -354,7 +354,7 @@ class DefaultGCExchangeFacadeContractTest {
       String submissionName = padEnd(testName, 150, '\u2190', '\u21FF');
 
       try (GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties)) {
-        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)));
+        String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(StandardCharsets.UTF_8)), null);
         long submissionId = facade.submitSubmission(
                 submissionName,
                 null,
@@ -485,7 +485,7 @@ class DefaultGCExchangeFacadeContractTest {
     for (Locale targetLocale : targetLocales) {
       String xliffContent = String.format(XLIFF_CONTENT_PATTERN, masterLocale.toLanguageTag(), targetLocale.toLanguageTag());
       String fileName = String.format("%s_%s2%s.xliff", testName, masterLocale.toLanguageTag(), targetLocale.toLanguageTag());
-      String fileId = facade.uploadContent(fileName, new ByteArrayResource(xliffContent.getBytes(StandardCharsets.UTF_8)));
+      String fileId = facade.uploadContent(fileName, new ByteArrayResource(xliffContent.getBytes(StandardCharsets.UTF_8)), masterLocale);
       contentMapBuilder.put(fileId, Collections.singletonList(targetLocale));
     }
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
@@ -121,12 +121,13 @@ class DefaultGCExchangeFacadeTest {
       String expectedFileId = "1234-5678";
       String expectedFileName = testInfo.getDisplayName();
       byte[] expectedContent = {42};
+      Locale expectedSourceLocale = Locale.US;
 
       ArgumentCaptor<UploadFileRequest> uploadFileRequestCaptor = ArgumentCaptor.forClass(UploadFileRequest.class);
       when(gcExchange.uploadContent(any())).thenReturn(expectedFileId);
 
       try (GCExchangeFacade facade = new MockDefaultGCExchangeFacade(gcExchange)) {
-        String actualFileId = facade.uploadContent(expectedFileName, new ByteArrayResource(expectedContent));
+        String actualFileId = facade.uploadContent(expectedFileName, new ByteArrayResource(expectedContent), expectedSourceLocale);
 
         assertThat(actualFileId).isEqualTo(expectedFileId);
 
@@ -136,6 +137,7 @@ class DefaultGCExchangeFacadeTest {
         assertions.assertThat(actualRequest.getFileName()).isEqualTo(expectedFileName);
         assertions.assertThat(actualRequest.getFileType()).isEqualTo("xliff");
         assertions.assertThat(actualRequest.getContents()).isEqualTo(expectedContent);
+        assertions.assertThat(actualRequest.getSourceLocale()).isEqualTo(expectedSourceLocale.toLanguageTag());
         assertions.assertAll();
       }
     }
@@ -150,7 +152,7 @@ class DefaultGCExchangeFacadeTest {
       Mockito.when(resource.getFilename()).thenReturn(someResourceFilename);
 
       try (GCExchangeFacade facade = new MockDefaultGCExchangeFacade(gcExchange)) {
-        assertThatThrownBy(() -> facade.uploadContent(someFilename, resource))
+        assertThatThrownBy(() -> facade.uploadContent(someFilename, resource, null))
                 .isInstanceOf(GCFacadeIOException.class)
                 .hasCauseInstanceOf(IOException.class)
                 .hasMessageContaining(someResourceFilename)
@@ -164,7 +166,7 @@ class DefaultGCExchangeFacadeTest {
       when(gcExchange.uploadContent(any())).thenThrow(RuntimeException.class);
 
       try (GCExchangeFacade facade = new MockDefaultGCExchangeFacade(gcExchange)) {
-        assertThatThrownBy(() -> facade.uploadContent(expectedFileName, new ByteArrayResource(new byte[]{42})))
+        assertThatThrownBy(() -> facade.uploadContent(expectedFileName, new ByteArrayResource(new byte[]{42}), null))
                 .isInstanceOf(GCFacadeCommunicationException.class)
                 .hasCauseInstanceOf(RuntimeException.class)
                 .hasMessageContaining(expectedFileName);

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
@@ -59,7 +59,7 @@ public final class DisabledGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public String uploadContent(String fileName, Resource resource) {
+  public String uploadContent(String fileName, Resource resource, Locale sourceLocale) {
     throw createDisabledException();
   }
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
@@ -94,7 +94,7 @@ public final class MockedGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public String uploadContent(String fileName, Resource resource) {
+  public String uploadContent(String fileName, Resource resource, Locale sourceLocale) {
     if (mockError == MockGCExchangeFacadeProvider.MockError.UPLOAD_COMMUNICATION) {
       throw new GCFacadeCommunicationException("Exception to test upload communication errors with translation service.");
     }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/test/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/test/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacadeTest.java
@@ -49,7 +49,7 @@ class MockedGCExchangeFacadeTest {
       // Let the tasks proceed faster.
       facade.setDelayBaseSeconds(2).setDelayOffsetPercentage(20);
 
-      String fileId = facade.uploadContent(testName, xliffResource);
+      String fileId = facade.uploadContent(testName, xliffResource, null);
       long submissionId = facade.submitSubmission(
               testName,
               null,
@@ -109,7 +109,7 @@ class MockedGCExchangeFacadeTest {
       // Let the tasks proceed faster.
       facade.setDelayBaseSeconds(2).setDelayOffsetPercentage(20);
 
-      String fileId = facade.uploadContent(testName, xliffResource);
+      String fileId = facade.uploadContent(testName, xliffResource, Locale.US);
       long submissionId = facade.submitSubmission(
               "states:other,cancelled",
               null,

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
@@ -43,11 +43,12 @@ public interface GCExchangeFacade extends AutoCloseable {
    *
    * @param fileName the filename of the resource
    * @param resource the resource to send
+   * @param sourceLocale source locale (optional)
    * @return file ID to be used later on to submit the submission
    * @throws GCFacadeIOException            if the resource cannot be read
    * @throws GCFacadeCommunicationException if the file cannot be uploaded
    */
-  String uploadContent(String fileName, Resource resource);
+  String uploadContent(String fileName, Resource resource, Locale sourceLocale);
 
   /**
    * Submit submission for the given contents uploaded before.
@@ -58,11 +59,11 @@ public interface GCExchangeFacade extends AutoCloseable {
    * @param workflow     translation workflow to be used, if not the default (optional)
    * @param submitter    name of the submitter (optional)
    * @param sourceLocale source locale
-   * @param contentMap   file IDs (returned by {@link #uploadContent(String, Resource)}) to translate
+   * @param contentMap   file IDs (returned by {@link #uploadContent(String, Resource, Locale)}) to translate
    *                     with the desired target locales to translate to
    * @return ID of the submission; to be used to track the state later on
    * @throws GCFacadeCommunicationException if submitting the submission failed
-   * @see #uploadContent(String, Resource)
+   * @see #uploadContent(String, Resource, Locale)
    */
   long submitSubmission(@Nullable String subject, @Nullable String comment, ZonedDateTime dueDate,
                         @Nullable String workflow, @Nullable String submitter, Locale sourceLocale,

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkAction.java
@@ -264,7 +264,7 @@ public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAct
       Path xliffPath = exportToXliff(sourceLocale, entry);
       String fileName = sourceLocale.toLanguageTag() + '2' + targetLocale + ".xliff";
       try {
-        String fileId = gccSession.uploadContent(fileName, new FileSystemResource(xliffPath));
+        String fileId = gccSession.uploadContent(fileName, new FileSystemResource(xliffPath), sourceLocale);
         builder.put(fileId, Collections.singletonList(entry.getKey()));
         LOG.debug(
                 "submitSubmission/Upload: Succeeded for {} translation items, target locale {}. Uploaded as fileId {} to GCC.",

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkActionTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkActionTest.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_SINGLETON;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
 
@@ -94,7 +95,7 @@ class SendToGlobalLinkActionTest {
 
     Mockito.doAnswer(invocation -> readXliff(invocation, expectedFileId, uploadedXliff))
             .when(gcExchangeFacade)
-            .uploadContent(anyString(), any(Resource.class));
+            .uploadContent(anyString(), any(Resource.class), any(Locale.class));
 
     Mockito.doReturn(expectedSubmissionId).when(gcExchangeFacade).submitSubmission(anyString(), anyString(), any(ZonedDateTime.class), anyString(), anyString(), any(Locale.class), anyMap());
 
@@ -111,7 +112,7 @@ class SendToGlobalLinkActionTest {
     ArgumentCaptor<Map<String, List<Locale>>> contentMapCaptor = ArgumentCaptor.forClass(Map.class);
     ArgumentCaptor<Locale> masterLocaleCaptor = ArgumentCaptor.forClass(Locale.class);
 
-    Mockito.verify(gcExchangeFacade).uploadContent(anyString(), any(Resource.class));
+    Mockito.verify(gcExchangeFacade).uploadContent(anyString(), any(Resource.class), eq(masterLocale));
     Mockito.verify(gcExchangeFacade).submitSubmission(anyString(), anyString(), any(ZonedDateTime.class), anyString(), anyString(), masterLocaleCaptor.capture(), contentMapCaptor.capture());
 
     assertThat(uploadedXliff[0])


### PR DESCRIPTION
When uploading the XLIFF file, if locales are being mapped on GCC side (see #31), the upload call requires the `source_locale` parameter. Otherwise the locale mapping cannot be done on GCC side.

We have been trying to get this to work together with GCC and the proposed solution came from Eduardo Aguilera of Transperfect:

> You need to make a change in the code to specify the source language when uploading content: you need to specify the parameter “source_locale” during the upload of the content (I don’t know if you recall it, but I think we discussed yesterday that this call was missing in Coremedia code).
> 
> Therefore, you will need to read the content locale from Coremedia and pass it as a parameter when uploading the file to GCC.

It's rather simple to fix this, but I cannot do it by customizing or extending the CoreMedia code, it has to be modified.