### PR TITLE
Fixes For Default Due Date Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,12 @@
 
 ### IntelliJ IDEA ###
 
-/.idea/
+.idea/
 *.iml
 
 ### Visual Studio Code ###
 
-/.vscode/
+.vscode/
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ v2406.0-1
 --------------------------------------------------------------------------------
 
 * Updated dependencies to CoreMedia Content Cloud v12.2406.0.1.
+* Fixed Due Date handling for invalid configured values of
+  `globallink.dayOffsetForDueDate`.
+* Refactored access to settings for Translation Service in studio-client to
+  an extra class.
 
 v2404.1-1
 --------------------------------------------------------------------------------

--- a/apps/studio-client/shared/js/gcc/src/GccWorkflowPlugin.ts
+++ b/apps/studio-client/shared/js/gcc/src/GccWorkflowPlugin.ts
@@ -3,9 +3,6 @@ import localesService from "@coremedia/studio-client.cap-base-models/locale/loca
 import ContentRepositoryImpl from "@coremedia/studio-client.cap-rest-client-impl/content/impl/ContentRepositoryImpl";
 import TaskDefinitionImpl from "@coremedia/studio-client.cap-rest-client-impl/workflow/impl/TaskDefinitionImpl";
 import session from "@coremedia/studio-client.cap-rest-client/common/session";
-import Content from "@coremedia/studio-client.cap-rest-client/content/Content";
-import Struct from "@coremedia/studio-client.cap-rest-client/struct/Struct";
-import StructRemoteBean from "@coremedia/studio-client.cap-rest-client/struct/StructRemoteBean";
 import Process from "@coremedia/studio-client.cap-rest-client/workflow/Process";
 import Task from "@coremedia/studio-client.cap-rest-client/workflow/Task";
 import WorkflowObjectProperties from "@coremedia/studio-client.cap-rest-client/workflow/WorkflowObjectProperties";
@@ -26,13 +23,13 @@ import { workflowPlugins } from "@coremedia/studio-client.workflow-plugin-models
 import DateUtil from "@jangaroo/ext-ts/Date";
 import { as, is } from "@jangaroo/runtime";
 import resourceManager from "@jangaroo/runtime/l10n/resourceManager";
-import Logger from "@coremedia/studio-client.client-core-impl/logging/Logger";
 import GccWorkflowLocalization_properties from "./GccWorkflowLocalization_properties";
 import Gcc_properties from "./Gcc_properties";
 import gccCanceledIcon from "./icons/global-link-workflow-canceled.svg";
 import gccIcon from "./icons/global-link-workflow.svg";
 import gccCancelActionIcon from "./icons/remove.svg";
 import gccWarningIcon from "./icons/warning.svg";
+import { translationServicesSettings } from "./TranslationServiceSettings";
 
 const UNAVAILABLE_SUBMISSION_STATE: string = "unavailable";
 const BLOB_FILE_PROCESS_VARIABLE_NAME: string = "translationResultXliff";
@@ -55,7 +52,6 @@ const HANDLE_SEND_TRANSLATION_REQUEST_ERROR_TASK_NAME: string = "HandleSendTrans
 const HANDLE_DOWNLOAD_TRANSLATION_ERROR_TASK_NAME: string = "HandleDownloadTranslationError";
 const HANDLE_CANCEL_TRANSLATION_ERROR_TASK_NAME: string = "HandleCancelTranslationError";
 const MILLISECONDS_FOR_ONE_DAY: number = 86400000;
-const CMSETTINGS_TYPE: string = "CMSettings";
 
 interface GccViewModel {
   globalLinkPdSubmissionIds?: string;
@@ -504,50 +500,20 @@ function createQuickTipText(locales: Array<any>, localesService: ILocalesService
   return localeQuickTipText;
 }
 
-function getDefaultDueDate(): Calendar {
-  const translationServices: Content = session._.getConnection()
-    .getContentRepository()
-    .getChild("/Settings/Options/Settings/Translation Services");
-  const settings: Array<Content> = [];
-  if (!RemoteBeanUtil.isAccessible(translationServices)) {
-    return undefined;
-  } else if (translationServices.isFolder()) {
-    settings.push(...translationServices.getChildDocuments());
-  } else if (translationServices.getType().isSubtypeOf(CMSETTINGS_TYPE)) {
-    settings.push(translationServices);
-  } else {
+function getDefaultDueDate(): Calendar | undefined {
+  const dayOffsetForDueDate = translationServicesSettings.getDayOffsetForDueDate();
+  if (dayOffsetForDueDate === undefined) {
     return undefined;
   }
 
-  for (const content of settings) {
-    if (RemoteBeanUtil.isAccessible(content) && content.getType().isSubtypeOf(CMSETTINGS_TYPE)) {
-      const calendar: Calendar = getDueDateFromSetting(content);
-      if (calendar) {
-        Logger.debug("Using due date from setting at " + content.getPath());
-        return calendar;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function getDueDateFromSetting(setting: Content): Calendar {
-  const gccConfig = setting.getProperties().get("settings") as StructRemoteBean;
-  if (RemoteBeanUtil.isAccessible(gccConfig) && gccConfig.get("globalLink")) {
-    const dayOffsetForDueDate: number = as(gccConfig.get("globalLink"), Struct).get("dayOffsetForDueDate");
-    if (dayOffsetForDueDate) {
-      const dateInFutureInMillieSeconds: number = new Date().getTime() + MILLISECONDS_FOR_ONE_DAY * dayOffsetForDueDate;
-      const dateInFuture = new Date(dateInFutureInMillieSeconds);
-      return new Calendar({
-        year: dateInFuture.getFullYear(),
-        month: dateInFuture.getMonth(),
-        day: dateInFuture.getDate(),
-        offset: -dateInFuture.getTimezoneOffset() * (60 * 1000),
-        timeZone: as(session._.getConnection().getContentRepository(), ContentRepositoryImpl).getDefaultTimeZone(),
-        normalized: true,
-      });
-    }
-  }
-  return undefined;
+  const dateInFutureInMillieSeconds = new Date().getTime() + MILLISECONDS_FOR_ONE_DAY * dayOffsetForDueDate;
+  const dateInFuture = new Date(dateInFutureInMillieSeconds);
+  return new Calendar({
+    year: dateInFuture.getFullYear(),
+    month: dateInFuture.getMonth(),
+    day: dateInFuture.getDate(),
+    offset: -dateInFuture.getTimezoneOffset() * (60 * 1000),
+    timeZone: as(session._.getConnection().getContentRepository(), ContentRepositoryImpl).getDefaultTimeZone(),
+    normalized: true,
+  });
 }

--- a/apps/studio-client/shared/js/gcc/src/TranslationServiceSettings.ts
+++ b/apps/studio-client/shared/js/gcc/src/TranslationServiceSettings.ts
@@ -161,7 +161,7 @@ export class TranslationServicesSettings {
     }
     // Return only those documents, that are of type CMSETTINGS_TYPE:
     const result = intermediateResult.filter((content) =>
-      content.getType().isSubtypeOf(TranslationServicesSettings.CMSETTINGS_TYPE),
+      content?.getType()?.isSubtypeOf(TranslationServicesSettings.CMSETTINGS_TYPE),
     );
     if (Logger.isDebugEnabled()) {
       const resultCsv = result.map((content) => `${content.getPath()} (${content})`).join(", ");

--- a/apps/studio-client/shared/js/gcc/src/TranslationServiceSettings.ts
+++ b/apps/studio-client/shared/js/gcc/src/TranslationServiceSettings.ts
@@ -1,0 +1,229 @@
+import { as } from "@jangaroo/runtime";
+import { session, Content, ContentRepository, Struct } from "@coremedia/studio-client.cap-rest-client";
+import ContentProperties from "@coremedia/studio-client.cap-rest-client/content/ContentProperties";
+import Logger from "@coremedia/studio-client.client-core-impl/logging/Logger";
+import RemoteBeanUtil from "@coremedia/studio-client.client-core/data/RemoteBeanUtil";
+
+/**
+ * Access to the settings for the translation services.
+ *
+ * Note, that this class only provides access to the global settings, not
+ * site specific settings.
+ */
+export class TranslationServicesSettings {
+  static #instance: TranslationServicesSettings = null;
+
+  /**
+   * Path where to search for appropriate settings documents.
+   */
+  static readonly MAIN_SETTINGS_PATH = "/Settings/Options/Settings";
+
+  /**
+   * The name of the settings. It either denotes the name of a settings document
+   * or a path in which to search for settings documents.
+   */
+  static readonly SETTINGS_NAME = "Translation Services";
+
+  /**
+   * Type to store TranslationSettings with.
+   */
+  static readonly CMSETTINGS_TYPE = "CMSettings";
+
+  /**
+   * The name of the global link property in settings struct.
+   */
+  static readonly P_GLOBALLINK = "globalLink";
+
+  /**
+   * The name of the property in settings struct that denotes the day offset for
+   * due dates.
+   */
+  static readonly P_DAY_OFFSET_FOR_DUE_DATE = "dayOffsetForDueDate";
+
+  /**
+   * The default offset to use, if no (or no valid) offset is set in the
+   * settings.
+   */
+  static readonly DEFAULT_DAY_OFFSET_FOR_DUE_DATE = 0;
+
+  #mainSettingsPath: Content | null | undefined = undefined;
+
+  /**
+   * Get content repository from session.
+   */
+  static #getRepository(): ContentRepository {
+    return session._.getConnection().getContentRepository();
+  }
+
+  /**
+   * Resolve the given path to either its content, `null`, if it is not existing
+   * or `undefined`, if it cannot be resolved yet.
+   *
+   * @param path - path to resolve
+   * @param folder - optional folder to search in
+   */
+  static #resolvePath(path: string, folder?: Content): Content | null | undefined {
+    const repository = TranslationServicesSettings.#getRepository();
+    return repository.getChild(path, null, folder);
+  }
+
+  /**
+   * Resolve path to a content, that is granted to be accessible. Automatically,
+   * also adds a tracked dependency to that content.
+   *
+   * @param path - path to resolve
+   * @param folder - optional folder to search in
+   */
+  static #resolveAccessiblePath(path: string, folder?: Content): Content | null | undefined {
+    const resolved = TranslationServicesSettings.#resolvePath(path, folder);
+    if (resolved === undefined) {
+      return undefined;
+    }
+
+    const accessible: boolean | undefined = RemoteBeanUtil.isAccessible(resolved);
+    if (accessible === undefined) {
+      return undefined;
+    }
+    if (accessible) {
+      return resolved;
+    }
+    return null;
+  }
+
+  /**
+   * Initialize the main settings path, if not already done.
+   */
+  #initMainSettingsPath(): void {
+    if (!this.#mainSettingsPath) {
+      this.#mainSettingsPath = TranslationServicesSettings.#resolveAccessiblePath(
+        TranslationServicesSettings.MAIN_SETTINGS_PATH,
+      );
+      if (Logger.isDebugEnabled() && this.#mainSettingsPath) {
+        Logger.debug(
+          `Main settings path initialized to: ${this.#mainSettingsPath.getPath()} (${this.#mainSettingsPath})`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Provides the main settings path, if it is accessible.
+   */
+  #resolveMainSettingsPath(): Content | null | undefined {
+    this.#initMainSettingsPath();
+    return this.#mainSettingsPath;
+  }
+
+  /**
+   * Resolve the root of the translation services settings. This may either
+   * be a document of the given name, or a folder, which again contains
+   * other settings documents.
+   */
+  #resolveTranslationServicesSettingsRoot(): Content | null | undefined {
+    const mainSettingsPath = this.#resolveMainSettingsPath();
+    if (!mainSettingsPath) {
+      return mainSettingsPath;
+    }
+    return TranslationServicesSettings.#resolveAccessiblePath(
+      TranslationServicesSettings.SETTINGS_NAME,
+      mainSettingsPath,
+    );
+  }
+
+  /**
+   * Finds relevant settings documents for translation services in a
+   * deterministic order.
+   */
+  #findSettings(): Content[] | undefined {
+    const settingsRoot = this.#resolveTranslationServicesSettingsRoot();
+    if (settingsRoot === undefined) {
+      return undefined;
+    }
+    if (settingsRoot === null || settingsRoot.isDestroyed()) {
+      return [];
+    }
+    const intermediateResult: Content[] = [];
+    if (settingsRoot.isDocument()) {
+      intermediateResult.push(settingsRoot);
+    } else {
+      // Adds contents sorted by name, so that we have a deterministic order.
+      intermediateResult.push(...settingsRoot.getChildDocuments());
+    }
+    // Return only those documents, that are of type CMSETTINGS_TYPE:
+    const result = intermediateResult.filter((content) =>
+      content.getType().isSubtypeOf(TranslationServicesSettings.CMSETTINGS_TYPE),
+    );
+    if (Logger.isDebugEnabled()) {
+      const resultCsv = result.map((content) => `${content.getPath()} (${content})`).join(", ");
+      Logger.debug(`Found ${result.length} settings documents for translation services: ${resultCsv}`);
+    }
+    return result;
+  }
+
+  /**
+   * Retrieves the `globallink` struct from the given settings document, if
+   * available.
+   */
+  static #getGlobalLink(settings: Content): Struct | null | undefined {
+    const properties: ContentProperties | undefined = settings.getProperties();
+    if (properties === undefined) {
+      return undefined;
+    }
+    return as(properties.get(TranslationServicesSettings.P_GLOBALLINK), Struct);
+  }
+
+  /**
+   * Retrieves the day offset for due dates from the given settings document,
+   * if available and if providing a suitable value (thus, a non-negative
+   * number).
+   */
+  static #getDayOffsetForDueDate(settings: Content): number | null | undefined {
+    const globallink: Struct | null | undefined = TranslationServicesSettings.#getGlobalLink(settings);
+    if (globallink === undefined) {
+      return undefined;
+    }
+    if (globallink === null) {
+      return null;
+    }
+    const result = globallink.get(TranslationServicesSettings.P_DAY_OFFSET_FOR_DUE_DATE);
+    if (typeof result !== "number" || result < 0) {
+      Logger.debug(
+        `Invalid day offset for due date in settings at: ${settings.getPath()}: ${result} (${typeof result})`,
+      );
+      return null;
+    }
+    return result;
+  }
+
+  getDayOffsetForDueDate(): number | undefined {
+    const settings = this.#findSettings();
+    if (settings === undefined) {
+      return undefined;
+    }
+    // Find first setting, that provides a number.
+    for (const setting of settings) {
+      const dayOffset = TranslationServicesSettings.#getDayOffsetForDueDate(setting);
+      if (typeof dayOffset === "number") {
+        if (Logger.isDebugEnabled()) {
+          Logger.debug(`Using day offset ${dayOffset} for due date from settings at: ${setting.getPath()}`);
+        }
+        return dayOffset;
+      }
+    }
+    Logger.debug("No available and valid day offset found in settings. Using default.");
+    return TranslationServicesSettings.DEFAULT_DAY_OFFSET_FOR_DUE_DATE;
+  }
+
+  static getInstance() {
+    if (this.#instance === null) {
+      this.#instance = new TranslationServicesSettings();
+      this.#instance.#initMainSettingsPath();
+    }
+    return this.#instance;
+  }
+}
+
+/**
+ * Provides access to the settings for the translation services.
+ */
+export const translationServicesSettings = TranslationServicesSettings.getInstance();


### PR DESCRIPTION
The default due date is read as `globallink.dayOffsetForDueDate` from `/Settings/Options/Settings/Translation Services` (as document, or as folder, containing multiple settings documents).

The existing approach does not cover some corner cases, and it accepted invalid values for due date offsets.

## Changelog

* The PR introduces `TranslationSeviceSettings` to wrap access to Translation Services settings.

* Prefer "public API" imports.

  While doing so, preferred "public API" exposed in `index.ts` over direct access to classes such as `Content` within that newly created class.

* Prevent "non-positive offsets" to be applied.

  In the previous state, a non-positive offset could have been added to the settings, causing a "due date in the past". This has been fixed along.