### PR TITLE
test: Enhance Contract Test

### DIFF
--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
@@ -8,8 +8,8 @@ import com.coremedia.labs.translation.gcc.facade.GCFacadeConnectorKeyConfigExcep
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionModel;
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
 import com.coremedia.labs.translation.gcc.facade.GCTaskModel;
-import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionInstruction;
 import com.coremedia.labs.translation.gcc.facade.config.CharacterType;
+import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionInstruction;
 import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionName;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
@@ -57,6 +57,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -305,7 +306,11 @@ class DefaultGCExchangeFacadeContractTest {
        * If cancellation fails because of invalid state: Extend the forbidden
        * states in the Awaitility call above.
        */
-      delegate.cancelSubmission(submissionId);
+      int status = facade.cancelSubmission(submissionId);
+
+      assertThat(status)
+        .as("Cancellation should have been successful.")
+        .isEqualTo(HTTP_OK);
 
       await("Wait until submission is marked as cancelled.")
         .atMost(2L, TimeUnit.MINUTES)


### PR DESCRIPTION
Now using facade to trigger cancellation as it should be.

Also, validating the status code, so that we may assume a successful cancellation request.

Nevertheless, given our currently provided GCC sandbox cancellation support within this test does not seem to be have as expected anymore. We may need to decide dropping the test eventually.