### PR TITLE
ci(github-actions): Update pnpm/actions-setup and Dependabot Adaptations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,8 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "dependencies"
-      - "maven"
-      - "build"
+      - "scope/dependencies"
+      - "type/build"
     open-pull-requests-limit: 5
 
   # Frontend dependencies managed by PNPM
@@ -28,9 +27,9 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "dependencies"
-      - "pnpm"
-      - "build"
+      - "scope/dependencies"
+      - "scope/website"
+      - "type/build"
     open-pull-requests-limit: 5
 
   # GitHub Actions
@@ -41,7 +40,7 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "dependencies"
-      - "github-actions"
-      - "ci"
+      - "scope/dependencies"
+      - "scope/github-actions"
+      - "type/ci"
     open-pull-requests-limit: 5

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::add-mask::${token}"
       - id: installPnpm
         name: "Install: Use PNPM ${{ env.PNPM_VERSION }}"
-        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false

--- a/.github/workflows/pages-test-deploy.yml
+++ b/.github/workflows/pages-test-deploy.yml
@@ -57,7 +57,7 @@ jobs:
           echo "::add-mask::${token}"
       - id: installPnpm
         name: "Install: Use PNPM ${{ env.PNPM_VERSION }}"
-        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false


### PR DESCRIPTION
* Updating `pnpm/actions-setup` to most recent version 4.1.0
* Fixing Dependabot configuration to use existing tags.