### PR TITLE
refactor: JSpecify

### DIFF
--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/pom.xml
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/pom.xml
@@ -41,12 +41,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacade.java
@@ -178,7 +178,7 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public String uploadContent(String fileName, Resource resource, Locale sourceLocale) {
+  public String uploadContent(String fileName, Resource resource, @Nullable Locale sourceLocale) {
     byte[] bytes;
     try (InputStream stream = resource.getInputStream()) {
       bytes = ByteStreams.toByteArray(stream);
@@ -187,7 +187,9 @@ public class DefaultGCExchangeFacade implements GCExchangeFacade {
     }
     try {
       UploadFileRequest request = new UploadFileRequest(bytes, fileName, fileTypeSupplier.get());
-      request.setSourceLocale(sourceLocale.toLanguageTag());
+      if (sourceLocale != null) {
+        request.setSourceLocale(sourceLocale.toLanguageTag());
+      }
       return delegate.uploadContent(request);
     } catch (GCFacadeException e) {
       throw e;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeProvider.java
@@ -2,12 +2,11 @@ package com.coremedia.labs.translation.gcc.facade.def;
 
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacade;
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacadeProvider;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class DefaultGCExchangeFacadeProvider implements GCExchangeFacadeProvider {
   private static final String TYPE_TOKEN = "default";
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/GCUtil.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/GCUtil.java
@@ -1,10 +1,9 @@
 package com.coremedia.labs.translation.gcc.facade.def;
 
 import com.coremedia.labs.translation.gcc.facade.GCFacadeCommunicationException;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.gs4tr.gcc.restclient.dto.PageableResponseData;
 import org.gs4tr.gcc.restclient.request.PageableRequest;
+import org.jspecify.annotations.NullMarked;
 
 import java.time.ZonedDateTime;
 import java.util.Date;
@@ -16,7 +15,7 @@ import static java.time.ZoneOffset.UTC;
 /**
  * Utility class for GCC Facade.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class GCUtil {
 
   private GCUtil() {

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/SLF4JHandler.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/main/java/com/coremedia/labs/translation/gcc/facade/def/SLF4JHandler.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade.def;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,8 +14,8 @@ import java.util.logging.LogRecord;
  *
  * @since 2406.1
  */
+@NullMarked
 final class SLF4JHandler extends Handler {
-  @NonNull
   private final Logger slf4jLogger;
 
   private SLF4JHandler(String loggerName) {
@@ -24,8 +24,7 @@ final class SLF4JHandler extends Handler {
     setFilter(null);
   }
 
-  @NonNull
-  public static java.util.logging.Logger getLogger(@NonNull String name) {
+  public static java.util.logging.Logger getLogger(String name) {
     java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
     logger.setLevel(Level.ALL);
     logger.setUseParentHandlers(false);
@@ -33,13 +32,12 @@ final class SLF4JHandler extends Handler {
     return logger;
   }
 
-  @NonNull
-  public static java.util.logging.Logger getLogger(@NonNull Class<?> clazz) {
+  public static java.util.logging.Logger getLogger(Class<?> clazz) {
     return getLogger(clazz.getName());
   }
 
   @Override
-  public void publish(@NonNull LogRecord record) {
+  public void publish(LogRecord record) {
     Level level = record.getLevel();
     String message = record.getMessage();
     Throwable thrown = record.getThrown();

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeContractTest.java
@@ -13,14 +13,14 @@ import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionInstruction;
 import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionName;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gs4tr.gcc.restclient.GCExchange;
 import org.gs4tr.gcc.restclient.model.GCFile;
 import org.gs4tr.gcc.restclient.model.LocaleConfig;
 import org.gs4tr.gcc.restclient.operation.ConnectorsConfig;
 import org.gs4tr.gcc.restclient.operation.Content;
 import org.gs4tr.gcc.restclient.request.PageableRequest;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -89,6 +89,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * }</pre>
  */
 @ExtendWith(GccCredentialsExtension.class)
+@NullMarked
 class DefaultGCExchangeFacadeContractTest {
   private static final Logger LOG = getLogger(lookup().lookupClass());
   private static final String XML_CONTENT = """
@@ -119,7 +120,7 @@ class DefaultGCExchangeFacadeContractTest {
   private String testName;
 
   @BeforeEach
-  void setUp(@NonNull TestInfo testInfo) {
+  void setUp(TestInfo testInfo) {
     testName = testInfo.getTestMethod().map(Method::getName).orElse("noname");
     submissionName = "%s: %s".formatted(TEST_ID, testName);
   }
@@ -134,7 +135,7 @@ class DefaultGCExchangeFacadeContractTest {
   class Login {
     @Test
     @DisplayName("Validate that login works.")
-    void shouldLoginSuccessfully(@NonNull Map<String, Object> gccProperties) {
+    void shouldLoginSuccessfully(Map<String, Object> gccProperties) {
       LOG.info("Properties: {}", gccProperties);
       assertThatCode(() -> new DefaultGCExchangeFacade(gccProperties))
         .doesNotThrowAnyException();
@@ -142,7 +143,7 @@ class DefaultGCExchangeFacadeContractTest {
 
     @Test
     @DisplayName("Validate that invalid login is denied.")
-    void shouldFailToLoginWithInvalidApiKey(@NonNull Map<String, Object> gccProperties) {
+    void shouldFailToLoginWithInvalidApiKey(Map<String, Object> gccProperties) {
       Map<String, Object> patchedProperties = new HashMap<>(gccProperties);
       patchedProperties.put("apiKey", "invalid");
       LOG.info("Properties: {} patched to {}", gccProperties, patchedProperties);
@@ -158,7 +159,7 @@ class DefaultGCExchangeFacadeContractTest {
      * submission by ID), we validate the connector key initially instead.
      */
     @Test
-    void shouldValidateConnectorKeyInitially(@NonNull Map<String, Object> gccProperties) {
+    void shouldValidateConnectorKeyInitially(Map<String, Object> gccProperties) {
       Map<String, Object> patchedProperties = new HashMap<>(gccProperties);
       patchedProperties.put("key", "invalid");
       LOG.info("Properties: {} patched to {}", gccProperties, patchedProperties);
@@ -229,7 +230,7 @@ class DefaultGCExchangeFacadeContractTest {
   class ContentUpload {
     @Test
     @DisplayName("Upload File.")
-    void upload(@NonNull Map<String, Object> gccProperties) {
+    void upload(Map<String, Object> gccProperties) {
       Instant startTimeUtc = Instant.now().atZone(ZoneOffset.UTC).toInstant();
 
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
@@ -274,9 +275,8 @@ class DefaultGCExchangeFacadeContractTest {
   class Cancellation {
     @Test
     @DisplayName("Be aware of submission/task cancellation.")
-    void shouldBeCancellationAware(@NonNull Map<String, Object> gccProperties) {
+    void shouldBeCancellationAware(Map<String, Object> gccProperties) {
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
-      GCExchange delegate = facade.getDelegate();
 
       String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(UTF_8)), null);
       long submissionId = facade.submitSubmission(
@@ -359,7 +359,7 @@ class DefaultGCExchangeFacadeContractTest {
   class ContentSubmission {
     @Test
     @DisplayName("Test simple submission")
-    void submitXml(@NonNull Map<String, Object> gccProperties) {
+    void submitXml(Map<String, Object> gccProperties) {
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
       String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(UTF_8)), null);
       long submissionId = facade.submitSubmission(
@@ -388,9 +388,9 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest
     @DisplayName("Should respect isSendSubmitter state.")
     @EnumSource(SendSubmitter.class)
-    void shouldRespectSubmitter(@NonNull SendSubmitter sendSubmitter,
-                                @NonNull Map<String, Object> originalGccProperties) {
-      Map<String, Object> gccProperties = new HashMap<>(originalGccProperties);
+    void shouldRespectSubmitter(SendSubmitter sendSubmitter,
+                                Map<String, Object> originalGccProperties) {
+      Map<String, @Nullable Object> gccProperties = new HashMap<>(originalGccProperties);
       gccProperties.put(GCConfigProperty.KEY_IS_SEND_SUBMITTER, sendSubmitter.getSendSubmitter());
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
       String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(UTF_8)), null);
@@ -429,8 +429,8 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest
     @DisplayName("Should accept various characters in the submitter name.")
     @EnumSource(SupplementaryMultilingualPlaneChallenge.class)
-    void shouldAcceptSubmitterNameChallenge(@NonNull SupplementaryMultilingualPlaneChallenge challenge,
-                                            @NonNull Map<String, Object> originalGccProperties) {
+    void shouldAcceptSubmitterNameChallenge(SupplementaryMultilingualPlaneChallenge challenge,
+                                            Map<String, Object> originalGccProperties) {
       Map<String, Object> gccProperties = new HashMap<>(originalGccProperties);
       gccProperties.put(GCConfigProperty.KEY_IS_SEND_SUBMITTER, true);
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
@@ -483,7 +483,7 @@ class DefaultGCExchangeFacadeContractTest {
      * removed.
      */
     @Test
-    void shouldExposeErrorStateToClient(@NonNull Map<String, Object> originalGccProperties) {
+    void shouldExposeErrorStateToClient(Map<String, Object> originalGccProperties) {
       Map<String, Object> gccProperties = new HashMap<>(originalGccProperties);
       // The only known way to provoke a failure for now is using a
       // high Unicode character and set it unmodified as instruction text.
@@ -523,8 +523,8 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest
     @DisplayName("Should respect and nicely handle instructions aka comments.")
     @EnumSource(CommentFixture.class)
-    void shouldRespectInstructions(@NonNull CommentFixture fixture,
-                                   @NonNull Map<String, Object> gccProperties) {
+    void shouldRespectInstructions(CommentFixture fixture,
+                                   Map<String, Object> gccProperties) {
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
       String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(UTF_8)), null);
       long submissionId = facade.submitSubmission(
@@ -556,8 +556,8 @@ class DefaultGCExchangeFacadeContractTest {
     @ParameterizedTest
     @DisplayName("Should prevent failures in GCC backend for problematic characters in the submission name.")
     @EnumSource(SupplementaryMultilingualPlaneChallenge.class)
-    void shouldPreemptivelyReplaceProblematicCharactersInSubmissionNames(@NonNull SupplementaryMultilingualPlaneChallenge challenge,
-                                                                         @NonNull Map<String, Object> gccProperties) {
+    void shouldPreemptivelyReplaceProblematicCharactersInSubmissionNames(SupplementaryMultilingualPlaneChallenge challenge,
+                                                                         Map<String, Object> gccProperties) {
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
       String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(UTF_8)), null);
       String submissionNameChallenge = "%s(%s)".formatted(submissionName, challenge.getChallenge());
@@ -598,8 +598,8 @@ class DefaultGCExchangeFacadeContractTest {
 
     @ParameterizedTest
     @EnumSource(SubmissionNameLengthFixture.class)
-    void shouldPreemptivelyTruncateLongSubmissionNames(@NonNull SubmissionNameLengthFixture fixture,
-                                                       @NonNull Map<String, Object> gccProperties) {
+    void shouldPreemptivelyTruncateLongSubmissionNames(SubmissionNameLengthFixture fixture,
+                                                       Map<String, Object> gccProperties) {
       String paddedSubmissionName = fixture.pad(submissionName);
       GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
       String fileId = facade.uploadContent(testName, new ByteArrayResource(XML_CONTENT.getBytes(UTF_8)), null);
@@ -649,7 +649,7 @@ class DefaultGCExchangeFacadeContractTest {
   @Tag("slow")
   @Tag("full")
   @DisplayName("Translate XLIFF and receive results (takes about 10 Minutes)")
-  void translateXliff(@NonNull Map<String, Object> gccProperties) {
+  void translateXliff(Map<String, Object> gccProperties) {
     GCExchangeFacade facade = new DefaultGCExchangeFacade(gccProperties);
     ConnectorsConfig.ConnectorsConfigResponseData connectorsConfig = facade.getDelegate().getConnectorsConfig();
     List<Locale> targetLocales = getSupportedLocaleStream(connectorsConfig, lc -> !lc.getIsSource()).toList();
@@ -690,7 +690,6 @@ class DefaultGCExchangeFacadeContractTest {
     public boolean test(InputStream is, GCTaskModel task) {
       ByteSource byteSource = new ByteSource() {
         @Override
-        @NonNull
         public InputStream openStream() {
           return is;
         }
@@ -773,8 +772,7 @@ class DefaultGCExchangeFacadeContractTest {
     }
   }
 
-  @NonNull
-  private static String padEnd(@NonNull String str, int minLength, char startChar, char endChar) {
+  private static String padEnd(String str, int minLength, char startChar, char endChar) {
     StringBuilder builder = new StringBuilder(str);
     char currentChar = startChar;
     while (builder.length() < minLength) {
@@ -849,7 +847,7 @@ class DefaultGCExchangeFacadeContractTest {
       this.endChar = endChar;
     }
 
-    public String pad(@NonNull String original) {
+    public String pad(String original) {
       return padEnd(original, minLength, startChar, endChar);
     }
   }
@@ -889,14 +887,12 @@ class DefaultGCExchangeFacadeContractTest {
       \t* Block: Miscellaneous Symbols and Pictographs, Dove: \uD83D\uDD4A (U+1F54A)
       EOM""");
 
-    @NonNull
     private final String comment;
 
-    CommentFixture(@NonNull String comment) {
+    CommentFixture(String comment) {
       this.comment = comment;
     }
 
-    @NonNull
     public String getComment() {
       return comment;
     }
@@ -908,14 +904,12 @@ class DefaultGCExchangeFacadeContractTest {
     BMP("ä&→\uFF01"),
     SMP("Dove: \uD83D\uDD4A");
 
-    @NonNull
     private final String challenge;
 
-    SupplementaryMultilingualPlaneChallenge(@NonNull String challenge) {
+    SupplementaryMultilingualPlaneChallenge(String challenge) {
       this.challenge = challenge;
     }
 
-    @NonNull
     public String getChallenge() {
       return challenge;
     }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/DefaultGCExchangeFacadeTest.java
@@ -14,9 +14,6 @@ import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionInstruction;
 import com.coremedia.labs.translation.gcc.facade.config.GCSubmissionName;
 import com.coremedia.labs.translation.gcc.facade.config.TextTransform;
 import com.google.common.io.ByteStreams;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.assertj.core.api.SoftAssertions;
 import org.gs4tr.gcc.restclient.GCExchange;
 import org.gs4tr.gcc.restclient.dto.MessageResponse;
@@ -32,6 +29,8 @@ import org.gs4tr.gcc.restclient.operation.Tasks;
 import org.gs4tr.gcc.restclient.request.SubmissionSubmitRequest;
 import org.gs4tr.gcc.restclient.request.TaskListRequest;
 import org.gs4tr.gcc.restclient.request.UploadFileRequest;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -84,7 +83,7 @@ import static org.mockito.Mockito.when;
  * Tests {@link DefaultGCExchangeFacade} by mocking the GCC REST Client API.
  */
 @ExtendWith(MockitoExtension.class)
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 class DefaultGCExchangeFacadeTest {
   private static final String LOREM_IPSUM = "Lorem Ipsum";
   private static final String MOCK_GCC_URL = "https://example.com";
@@ -259,7 +258,7 @@ class DefaultGCExchangeFacadeTest {
 
     @ParameterizedTest
     @EnumSource(IsSendSubmitterFixture.class)
-    void shouldRespectIsSendSubmitter(@NonNull IsSendSubmitterFixture fixture, @NonNull TestInfo testInfo) {
+    void shouldRespectIsSendSubmitter(IsSendSubmitterFixture fixture, TestInfo testInfo) {
       String id = testInfo.getTestMethod().map(Method::getName).orElse("unknown");
       Map<String, Object> config = new HashMap<>(requiredConfig);
       fixture.applyConfig(config);
@@ -331,7 +330,7 @@ class DefaultGCExchangeFacadeTest {
     @Nested
     class SubmissionNameUseCases {
       @Test
-      void shouldApplySourceTargetLocaleInformation(@NonNull TestInfo testInfo) {
+      void shouldApplySourceTargetLocaleInformation(TestInfo testInfo) {
         String subject = "Subject: %s".formatted(testInfo.getDisplayName());
         MockDefaultGCExchangeFacade facade = new MockDefaultGCExchangeFacade(requiredConfig, gcExchange);
         String fileId = "1234-5678";
@@ -628,7 +627,7 @@ class DefaultGCExchangeFacadeTest {
         when(gcExchange.confirmTask(eq(expectedTaskId))).thenReturn(true);
 
         GCExchangeFacade facade = new MockDefaultGCExchangeFacade(gcExchange);
-        String[] actualContentRead = {null};
+        @Nullable String[] actualContentRead = {null};
 
         facade.downloadCompletedTasks(expectedSubmissionId, new HappyPathTaskDataConsumer(actualContentRead));
 
@@ -997,10 +996,10 @@ class DefaultGCExchangeFacadeTest {
     STRING_ANY("anyString", false),
     ;
 
-    private final Object sendSubmitterConfig;
+    private final @Nullable Object sendSubmitterConfig;
     private final boolean expectedIsSendSubmitter;
 
-    IsSendSubmitterFixture(Object sendSubmitterConfig, boolean expectedIsSendSubmitter) {
+    IsSendSubmitterFixture(@Nullable Object sendSubmitterConfig, boolean expectedIsSendSubmitter) {
       this.sendSubmitterConfig = sendSubmitterConfig;
       this.expectedIsSendSubmitter = expectedIsSendSubmitter;
     }
@@ -1009,7 +1008,7 @@ class DefaultGCExchangeFacadeTest {
       return expectedIsSendSubmitter;
     }
 
-    public void applyConfig(@NonNull Map<String, Object> config) {
+    public void applyConfig(Map<String, @Nullable Object> config) {
       if ("unset".equals(sendSubmitterConfig)) {
         config.remove(GCConfigProperty.KEY_IS_SEND_SUBMITTER);
       } else {
@@ -1023,7 +1022,7 @@ class DefaultGCExchangeFacadeTest {
       super(delegate, "xliff");
     }
 
-    MockDefaultGCExchangeFacade(@NonNull Map<String, Object> config, @NonNull GCExchange delegate) {
+    MockDefaultGCExchangeFacade(Map<String, Object> config, GCExchange delegate) {
       super(config, cfg -> {
         lenient().when(delegate.getConfig()).thenReturn(cfg);
         Connector connector = Mockito.mock(Connector.class);
@@ -1033,14 +1032,13 @@ class DefaultGCExchangeFacadeTest {
       });
     }
 
-    @NonNull
     public ArgumentCaptor<SubmissionSubmitRequest> submitAnySubmission(@Nullable String subject,
                                                                        @Nullable String comment,
-                                                                       @NonNull ZonedDateTime dueDate,
+                                                                       ZonedDateTime dueDate,
                                                                        @Nullable String workflow,
                                                                        @Nullable String submitter,
-                                                                       @NonNull Locale sourceLocale,
-                                                                       @NonNull Map<String, List<Locale>> contentMap) {
+                                                                       Locale sourceLocale,
+                                                                       Map<String, List<Locale>> contentMap) {
       SubmissionSubmit.SubmissionSubmitResponseData response = Mockito.mock(SubmissionSubmit.SubmissionSubmitResponseData.class);
       long expectedSubmissionId = 42L;
 
@@ -1052,8 +1050,7 @@ class DefaultGCExchangeFacadeTest {
       return submissionSubmitRequestCaptor;
     }
 
-    @NonNull
-    private GCSubmission prepareGetSubmissionMock(@NonNull SubmissionStatus status) {
+    private GCSubmission prepareGetSubmissionMock(SubmissionStatus status) {
       GCSubmission submission = Mockito.mock(GCSubmission.class);
       Status submissionStatus = Mockito.mock(Status.class);
       lenient().when(submission.getStatus()).thenReturn(submissionStatus);
@@ -1071,7 +1068,6 @@ class DefaultGCExchangeFacadeTest {
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    @NonNull
     public GCSubmissionModel getNotExistingSubmission() {
       Submissions.SubmissionsResponseData response = Mockito.mock(Submissions.SubmissionsResponseData.class);
 
@@ -1080,14 +1076,12 @@ class DefaultGCExchangeFacadeTest {
       return getSubmission(42L);
     }
 
-    @NonNull
     public GCSubmissionModel getSuccessfulSubmission() {
       GCSubmission submission = prepareGetSubmissionMock(SubmissionStatus.Completed);
       when(submission.getIsError()).thenReturn(Boolean.FALSE);
       return getSubmission(42L);
     }
 
-    @NonNull
     public GCSubmissionModel getErredSubmission() {
       GCSubmission submission = prepareGetSubmissionMock(SubmissionStatus.PreProcess);
       when(submission.getIsError()).thenReturn(Boolean.TRUE);

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/GCUtilTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-default/src/test/java/com/coremedia/labs/translation/gcc/facade/def/GCUtilTest.java
@@ -1,10 +1,10 @@
 package com.coremedia.labs.translation.gcc.facade.def;
 
 import com.coremedia.labs.translation.gcc.facade.GCFacadeCommunicationException;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.assertj.core.api.Assertions;
 import org.gs4tr.gcc.restclient.dto.PageableResponseData;
 import org.gs4tr.gcc.restclient.request.PageableRequest;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Tests {@link GCUtil}.
  */
+@NullMarked
 class GCUtilTest {
   @SuppressWarnings("UseOfObsoleteDateTimeApi")
   @ParameterizedTest
@@ -114,8 +115,8 @@ class GCUtilTest {
 
   private static final class InstantArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
-                                                        @NonNull ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters,
+                                                        ExtensionContext context) {
       LocalDateTime someTime = LocalDateTime.of(2018, 7, 15, 13, 11, 30, 0);
       return Stream.concat(
           Stream.of(

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/pom.xml
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/pom.xml
@@ -24,21 +24,13 @@
       <artifactId>gcc-restclient</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
@@ -50,7 +50,7 @@ public final class DisabledGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public String uploadContent(String fileName, Resource resource, Locale sourceLocale) {
+  public String uploadContent(String fileName, Resource resource, @Nullable Locale sourceLocale) {
     throw createDisabledException();
   }
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacade.java
@@ -5,10 +5,9 @@ import com.coremedia.labs.translation.gcc.facade.GCExchangeFacadeSessionProvider
 import com.coremedia.labs.translation.gcc.facade.GCFacadeException;
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionModel;
 import com.coremedia.labs.translation.gcc.facade.GCTaskModel;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gs4tr.gcc.restclient.GCExchange;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.io.Resource;
 
 import java.io.InputStream;
@@ -30,7 +29,7 @@ import java.util.function.BiPredicate;
  * To get an instance of this facade, use {@link GCExchangeFacadeSessionProvider}.
  * </p>
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public final class DisabledGCExchangeFacade implements GCExchangeFacade {
   private static final GCExchangeFacade INSTANCE = new DisabledGCExchangeFacade();
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-disabled/src/main/java/com/coremedia/labs/translation/gcc/facade/disabled/DisabledGCExchangeFacadeProvider.java
@@ -2,12 +2,11 @@ package com.coremedia.labs.translation.gcc.facade.disabled;
 
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacade;
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacadeProvider;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class DisabledGCExchangeFacadeProvider implements GCExchangeFacadeProvider {
   private static final String TYPE_TOKEN = "disabled";
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/pom.xml
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/pom.xml
@@ -41,12 +41,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/ContentStore.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/ContentStore.java
@@ -2,8 +2,7 @@ package com.coremedia.labs.translation.gcc.facade.mock;
 
 import com.coremedia.labs.translation.gcc.facade.GCFacadeIOException;
 import com.google.common.io.ByteSource;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.core.io.InputStreamSource;
 
 import java.io.IOException;
@@ -17,7 +16,7 @@ import java.util.UUID;
  * Part of mocking the content API. It will remember contents to be translated
  * until they are used within a translation submission.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class ContentStore {
   private final Map<String, String> store = new HashMap<>();
 
@@ -34,7 +33,6 @@ final class ContentStore {
     try (InputStream is = resource.getInputStream()) {
       ByteSource source = new ByteSource() {
         @Override
-        @NonNull
         public InputStream openStream() {
           return is;
         }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockGCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockGCExchangeFacadeProvider.java
@@ -3,14 +3,13 @@ package com.coremedia.labs.translation.gcc.facade.mock;
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacade;
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacadeProvider;
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
 import static com.coremedia.labs.translation.gcc.facade.mock.settings.MockSettings.fromGlobalLinkConfig;
 
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class MockGCExchangeFacadeProvider implements GCExchangeFacadeProvider {
   @VisibleForTesting
   static final String TYPE_TOKEN = "mock";

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
@@ -8,10 +8,9 @@ import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
 import com.coremedia.labs.translation.gcc.facade.GCTaskModel;
 import com.coremedia.labs.translation.gcc.facade.mock.settings.MockError;
 import com.coremedia.labs.translation.gcc.facade.mock.settings.MockSettings;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gs4tr.gcc.restclient.GCExchange;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.springframework.core.io.Resource;
 
@@ -38,7 +37,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * <p>
  * To get an instance of this facade, use {@link GCExchangeFacadeSessionProvider}.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public final class MockedGCExchangeFacade implements GCExchangeFacade {
   private static final Logger LOG = getLogger(lookup().lookupClass());
 
@@ -50,10 +49,9 @@ public final class MockedGCExchangeFacade implements GCExchangeFacade {
    * submissions across multiple facade instances.
    */
   private static final SubmissionStore submissionStore = SubmissionStore.getInstance();
-  @NonNull
   private final MockSettings mockSettings;
 
-  MockedGCExchangeFacade(@NonNull MockSettings mockSettings) {
+  MockedGCExchangeFacade(MockSettings mockSettings) {
     this.mockSettings = mockSettings;
     // By intention may adapt the settings also within the submission store
     // on each new instance creation of the facade. While this is not meant

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacade.java
@@ -72,7 +72,7 @@ public final class MockedGCExchangeFacade implements GCExchangeFacade {
   }
 
   @Override
-  public String uploadContent(String fileName, Resource resource, Locale sourceLocale) {
+  public String uploadContent(String fileName, Resource resource, @Nullable Locale sourceLocale) {
     if (mockSettings.error() == MockError.UPLOAD_COMMUNICATION) {
       throw new GCFacadeCommunicationException("Exception to test upload communication errors with translation service.");
     }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/Submission.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/Submission.java
@@ -4,9 +4,8 @@ import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
 import com.coremedia.labs.translation.gcc.facade.mock.settings.MockSettings;
 import com.coremedia.labs.translation.gcc.facade.mock.settings.MockSubmissionStates;
 import com.google.common.collect.ImmutableList;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Collection;
@@ -34,13 +33,11 @@ import static org.slf4j.LoggerFactory.getLogger;
  * does not need to know of jobs but just of submissions and tasks.
  * </p>
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class Submission {
   private static final Logger LOG = getLogger(lookup().lookupClass());
 
-  @NonNull
   private final MockSettings mockSettings;
-  @NonNull
   private final ImmutableList<Task> tasks;
 
   /**
@@ -66,8 +63,7 @@ final class Submission {
    *   </li>
    * </ul>
    */
-  @Nullable
-  private MockSubmissionStates.ReplayScenario activeReplayScenario;
+  private MockSubmissionStates.@Nullable ReplayScenario activeReplayScenario;
 
   /**
    * <p>
@@ -92,9 +88,9 @@ final class Submission {
    * @param submissionContents contents which shall be part of the submission
    * @param mockSettings       settings to control the behavior of the submission
    */
-  Submission(@NonNull String subject,
-             @NonNull List<SubmissionContent> submissionContents,
-             @NonNull MockSettings mockSettings) {
+  Submission(String subject,
+             List<SubmissionContent> submissionContents,
+             MockSettings mockSettings) {
     this.mockSettings = mockSettings;
     ImmutableList.Builder<Task> builder = ImmutableList.builder();
     for (SubmissionContent c : submissionContents) {
@@ -135,7 +131,6 @@ final class Submission {
     return possiblyOverrideByMockSubmissionState(result);
   }
 
-  @NonNull
   private Optional<GCSubmissionState> getSubmissionStateFromReplayScenario() {
     MockSubmissionStates.ReplayScenario scenario = activeReplayScenario;
     if (scenario == null) {
@@ -152,8 +147,7 @@ final class Submission {
     return nextState;
   }
 
-  @NonNull
-  private GCSubmissionState possiblyOverrideByMockSubmissionState(@NonNull GCSubmissionState originalSubmissionState) {
+  private GCSubmissionState possiblyOverrideByMockSubmissionState(GCSubmissionState originalSubmissionState) {
     if (activeReplayScenario != null) {
       // Prefer states from the replay scenario over the actual state.
       LOG.debug("Query existing replay scenario for state override of {}.", originalSubmissionState);

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/SubmissionContent.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/SubmissionContent.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.mock;
 
 import com.google.common.collect.ImmutableList;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 import java.util.Locale;
@@ -10,7 +9,7 @@ import java.util.Locale;
 /**
  * Represents a content which is part of a translation.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 record SubmissionContent(String fileId, String fileContent, List<Locale> targetLocales) {
   SubmissionContent(String fileId, String fileContent, List<Locale> targetLocales) {
     this.fileId = fileId;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/SubmissionStore.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/SubmissionStore.java
@@ -3,8 +3,7 @@ package com.coremedia.labs.translation.gcc.facade.mock;
 import com.coremedia.labs.translation.gcc.facade.GCFacadeSubmissionNotFoundException;
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
 import com.coremedia.labs.translation.gcc.facade.mock.settings.MockSettings;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -16,12 +15,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * Part of mocking the submission API. It will remember submissions, so that
  * you can later query their state.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class SubmissionStore {
   private static final AtomicLong NEXT_SUBMISSION_ID = new AtomicLong();
   private final Map<Long, Submission> submissions = new HashMap<>();
 
-  @NonNull
   private MockSettings mockSettings = MockSettings.EMPTY;
 
   /**
@@ -53,7 +51,7 @@ final class SubmissionStore {
    * are to be expected to be applied to new submissions and tasks only.
    * @param mockSettings the settings to apply
    */
-  public void applySettings(@NonNull MockSettings mockSettings) {
+  public void applySettings(MockSettings mockSettings) {
     this.mockSettings = mockSettings;
   }
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/Task.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/Task.java
@@ -1,15 +1,16 @@
 package com.coremedia.labs.translation.gcc.facade.mock;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
+import java.security.SecureRandom;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
 import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.random.RandomGenerator;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -28,11 +29,11 @@ import static org.slf4j.LoggerFactory.getLogger;
  * according to all contained tasks.
  * </p>
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class Task {
   private static final Logger LOG = getLogger(lookup().lookupClass());
 
-  private static final Random RANDOM = new Random();
+  private static final RandomGenerator RANDOM = new SecureRandom();
   private static final AtomicLong ID_FACTORY = new AtomicLong(System.currentTimeMillis());
 
   private final long id = ID_FACTORY.incrementAndGet();
@@ -66,7 +67,7 @@ final class Task {
    * @param targetLocale          targetLocale for the Task
    * @param taskStates            task states to reach based on timing; defaults to {@link TaskState#COMPLETED} if not set
    */
-  Task(String content, long delayBaseSeconds, int delayOffsetPercentage, Locale targetLocale, TaskState... taskStates) {
+  Task(String content, long delayBaseSeconds, int delayOffsetPercentage, Locale targetLocale, TaskState @Nullable... taskStates) {
     this.content = content;
     this.targetLocale = targetLocale;
     long currentTimeMillis = System.currentTimeMillis();

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/TaskStateListener.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/TaskStateListener.java
@@ -1,13 +1,12 @@
 package com.coremedia.labs.translation.gcc.facade.mock;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Interface for a listener which will receive a signal when a
  * task state changed.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 interface TaskStateListener {
   /**
    * Event receiver.

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/TranslationUtil.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/TranslationUtil.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.mock;
 
 import com.google.common.collect.ImmutableMap;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -35,7 +34,7 @@ import static java.util.stream.Collectors.joining;
 /**
  * Provides simple <em>mock</em> translation by replacing characters.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class TranslationUtil {
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final Map<String, String> TRANSLATE = ImmutableMap.<String, String>builder()

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/settings/MockError.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/settings/MockError.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade.mock.settings;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -8,6 +8,7 @@ import java.util.Optional;
 /**
  * Possible values for the {@code globalLink.mockError} setting.
  */
+@NullMarked
 public enum MockError {
   /**
    * Provokes a communication failure during the cancellation request.
@@ -36,8 +37,7 @@ public enum MockError {
   UPLOAD_COMMUNICATION,
   ;
 
-  @NonNull
-  public static Optional<MockError> tryParse(@NonNull String value) {
+  public static Optional<MockError> tryParse(String value) {
     if (value.isEmpty()) {
       return Optional.empty();
     }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/settings/MockSettings.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/settings/MockSettings.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.mock.settings;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Map;
@@ -13,11 +13,12 @@ import static org.slf4j.LoggerFactory.getLogger;
 /**
  * Settings for the Mock Facade.
  */
+@NullMarked
 public record MockSettings(
   long stateChangeDelaySeconds,
   int stateChangeDelayOffsetPercentage,
   @Nullable MockError error,
-  @NonNull MockSubmissionStates submissionStates
+  MockSubmissionStates submissionStates
 ) {
   private static final Logger LOG = getLogger(lookup().lookupClass());
 
@@ -26,7 +27,6 @@ public record MockSettings(
   /**
    * Empty settings (with defaults applied).
    */
-  @NonNull
   public static final MockSettings EMPTY = new MockSettings(
     DEFAULT_STATE_CHANGE_DELAY_SECONDS,
     DEFAULT_STATE_CHANGE_DELAY_OFFSET_PERCENTAGE,
@@ -97,8 +97,7 @@ public record MockSettings(
     }
   }
 
-  @NonNull
-  public static MockSettings fromGlobalLinkConfig(@NonNull Map<String, ?> config) {
+  public static MockSettings fromGlobalLinkConfig(Map<String, ?> config) {
     Object mockConfigObject = config.get(CONFIG_MOCK);
     if (mockConfigObject instanceof Map<?, ?> mockConfigMap) {
       return fromMockConfig(mockConfigMap);
@@ -106,8 +105,7 @@ public record MockSettings(
     return EMPTY;
   }
 
-  @NonNull
-  public static MockSettings fromMockConfig(@NonNull Map<?, ?> config) {
+  public static MockSettings fromMockConfig(Map<?, ?> config) {
     if (config.isEmpty()) {
       return EMPTY;
     }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/settings/MockSubmissionStates.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/main/java/com/coremedia/labs/translation/gcc/facade/mock/settings/MockSubmissionStates.java
@@ -1,8 +1,8 @@
 package com.coremedia.labs.translation.gcc.facade.mock.settings;
 
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -96,12 +96,11 @@ import static org.slf4j.LoggerFactory.getLogger;
  *         override: DELIVERED
  * }</pre>
  */
+@NullMarked
 public final class MockSubmissionStates {
   private static final Logger LOG = getLogger(lookup().lookupClass());
-  @NonNull
   public static final MockSubmissionStates EMPTY = new MockSubmissionStates(Map.of());
 
-  @NonNull
   private final Map<GCSubmissionState, StatePointcutConfig> statePointcutConfigs;
 
   /**
@@ -109,7 +108,7 @@ public final class MockSubmissionStates {
    *
    * @param statePointcutConfigs map of state pointcut configurations
    */
-  private MockSubmissionStates(@NonNull Map<GCSubmissionState, StatePointcutConfig> statePointcutConfigs) {
+  private MockSubmissionStates(Map<GCSubmissionState, StatePointcutConfig> statePointcutConfigs) {
     this.statePointcutConfigs = Map.copyOf(statePointcutConfigs);
   }
 
@@ -119,7 +118,7 @@ public final class MockSubmissionStates {
    * @param config configuration to parse
    * @return mock submission state behavior
    */
-  public static MockSubmissionStates fromConfig(@NonNull Map<?, ?> config) {
+  public static MockSubmissionStates fromConfig(Map<?, ?> config) {
     Map<GCSubmissionState, StatePointcutConfig> parsedConfig = parseConfig(config);
     if (parsedConfig.isEmpty()) {
       return EMPTY;
@@ -135,8 +134,7 @@ public final class MockSubmissionStates {
    * @return map of state pointcut configurations; on invalid or not existing
    * configuration an empty map will be returned
    */
-  @NonNull
-  private static Map<GCSubmissionState, StatePointcutConfig> parseConfig(@NonNull Map<?, ?> config) {
+  private static Map<GCSubmissionState, StatePointcutConfig> parseConfig(Map<?, ?> config) {
     Map<GCSubmissionState, StatePointcutConfig> result = new EnumMap<>(GCSubmissionState.class);
     for (Map.Entry<?, ?> entry : config.entrySet()) {
       if (!(entry.getKey() instanceof String stateName)) {
@@ -166,7 +164,7 @@ public final class MockSubmissionStates {
    * @return replay scenario; {@code null} if no replay scenario is available
    */
   @Nullable
-  public ReplayScenario getReplayScenario(@NonNull GCSubmissionState state) {
+  public ReplayScenario getReplayScenario(GCSubmissionState state) {
     StatePointcutConfig config = statePointcutConfigs.get(state);
     if (config == null) {
       LOG.trace("No mock submission state configuration for state: {}", state);
@@ -206,7 +204,7 @@ public final class MockSubmissionStates {
      * @param states     states to replay
      * @param finalState whether the last state is considered final
      */
-    private ReplayScenario(@NonNull Collection<GCSubmissionState> states,
+    private ReplayScenario(Collection<GCSubmissionState> states,
                            boolean finalState) {
       this.states = new LinkedList<>(states);
       this.finalState = finalState;
@@ -226,7 +224,6 @@ public final class MockSubmissionStates {
      *
      * @return next state to replay; empty if no more states are available
      */
-    @NonNull
     public Optional<GCSubmissionState> next() {
       if (states.isEmpty()) {
         LOG.trace("No more states available in replay scenario.");
@@ -240,7 +237,7 @@ public final class MockSubmissionStates {
         state = states.poll();
       }
       LOG.trace("State to replay: {}", state);
-      return Optional.ofNullable(state);
+      return Optional.of(state);
     }
   }
 
@@ -253,9 +250,9 @@ public final class MockSubmissionStates {
    * @param override   states to replace the original state
    */
   public record StatePointcutConfig(boolean finalState,
-                                    @NonNull List<GCSubmissionState> before,
-                                    @NonNull List<GCSubmissionState> after,
-                                    @NonNull List<GCSubmissionState> override
+                                    List<GCSubmissionState> before,
+                                    List<GCSubmissionState> after,
+                                    List<GCSubmissionState> override
   ) {
     /**
      * Checks if the state configuration is considered empty.
@@ -278,7 +275,6 @@ public final class MockSubmissionStates {
      * @param object configuration to parse
      * @return state pointcut configuration
      */
-    @NonNull
     public static Optional<StatePointcutConfig> fromConfig(@Nullable Object object) {
       if (!(object instanceof Map<?, ?> config) || config.isEmpty()) {
         return Optional.empty();
@@ -296,8 +292,7 @@ public final class MockSubmissionStates {
      * @param config configuration to parse
      * @return state pointcut configuration
      */
-    @NonNull
-    private static StatePointcutConfig parseStateConfig(@NonNull Map<?, ?> config) {
+    private static StatePointcutConfig parseStateConfig(Map<?, ?> config) {
       List<GCSubmissionState> before = parseStateList(config.get("before"));
       List<GCSubmissionState> after = parseStateList(config.get("after"));
       List<GCSubmissionState> override = parseStateList(config.get("override"));
@@ -315,7 +310,6 @@ public final class MockSubmissionStates {
      * @param config configuration to parse
      * @return list of submission states
      */
-    @NonNull
     private static List<GCSubmissionState> parseStateList(@Nullable Object config) {
       if (config instanceof String stateName) {
         Optional<GCSubmissionState> state = findSubmissionStateByName(stateName);

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/test/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacadeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade-mock/src/test/java/com/coremedia/labs/translation/gcc/facade/mock/MockedGCExchangeFacadeTest.java
@@ -7,9 +7,9 @@ import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
 import com.coremedia.labs.translation.gcc.facade.GCTaskModel;
 import com.coremedia.labs.translation.gcc.facade.mock.settings.MockSettings;
 import com.google.common.io.ByteSource;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
@@ -33,6 +33,7 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 
+@NullMarked
 class MockedGCExchangeFacadeTest {
   private static final Logger LOG = getLogger(lookup().lookupClass());
   private static final long TRANSLATION_TIMEOUT_MINUTES = 3L;
@@ -86,7 +87,6 @@ class MockedGCExchangeFacadeTest {
     public boolean test(InputStream is, GCTaskModel task) {
       ByteSource byteSource = new ByteSource() {
         @Override
-        @NonNull
         public InputStream openStream() {
           return is;
         }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/pom.xml
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/pom.xml
@@ -31,12 +31,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/DefaultGCExchangeFacadeSessionProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/DefaultGCExchangeFacadeSessionProvider.java
@@ -1,7 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -16,7 +15,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * Factory which, depending on given settings, will create either a
  * default communication channel to GCC, a mocked one or a disabled one.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public final class DefaultGCExchangeFacadeSessionProvider implements GCExchangeFacadeSessionProvider {
   private static final Logger LOG = getLogger(lookup().lookupClass());
 

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCConfigProperty.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCConfigProperty.java
@@ -1,13 +1,12 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Properties to be used in {@code GlobalLink} settings document.
  */
 @SuppressWarnings("UtilityClassCanBeEnum")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public final class GCConfigProperty {
   /**
    * Root node for GCC Settings in Struct.

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
@@ -47,7 +47,7 @@ public interface GCExchangeFacade {
    * @throws GCFacadeIOException            if the resource cannot be read
    * @throws GCFacadeCommunicationException if the file cannot be uploaded
    */
-  String uploadContent(String fileName, Resource resource, Locale sourceLocale);
+  String uploadContent(String fileName, Resource resource, @Nullable Locale sourceLocale);
 
   /**
    * Submit submission for the given contents uploaded before.

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacade.java
@@ -1,9 +1,8 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gs4tr.gcc.restclient.GCExchange;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.io.Resource;
 
 import java.io.InputStream;
@@ -22,7 +21,7 @@ import java.util.function.BiPredicate;
  * @implSpec Implementations of this interface must be stateless, as they are
  * recreated several times during the lifecycle of the translation workflow.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public interface GCExchangeFacade {
   /**
    * This is a convenience access to the embedded delegate. It should not be

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeProvider.java
@@ -1,14 +1,13 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
 /**
  * Service Provider Interface for GCExchange facades.
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public interface GCExchangeFacadeProvider {
   /**
    * Type token this SPI responds to.

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeSessionProvider.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCExchangeFacadeSessionProvider.java
@@ -1,7 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
@@ -11,8 +10,8 @@ import java.util.Map;
  * do real communication, some may provide mock answers for testing
  * purpose and others just may signal a disabled communication state.
  */
-@DefaultAnnotation(NonNull.class)
 @FunctionalInterface
+@NullMarked
 public interface GCExchangeFacadeSessionProvider {
   /**
    * <p>

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeAccessException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeAccessException.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
@@ -11,7 +10,7 @@ import java.io.Serial;
  * expired API key.
  */
 @SuppressWarnings("unused")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class GCFacadeAccessException extends GCFacadeException {
   @Serial
   private static final long serialVersionUID = -4226793602127027111L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeCommunicationException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeCommunicationException.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
@@ -10,7 +9,7 @@ import java.io.Serial;
  * Signals a communication error with the GCC REST Backend via GCC Java RestClient.
  */
 @SuppressWarnings("unused")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class GCFacadeCommunicationException extends GCFacadeException {
   @Serial
   private static final long serialVersionUID = -4226793602127027111L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeConfigException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeConfigException.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
@@ -10,7 +9,7 @@ import java.io.Serial;
  * Signals a configuration problem, like especially invalid settings.
  */
 @SuppressWarnings("unused")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class GCFacadeConfigException extends GCFacadeException {
   @Serial
   private static final long serialVersionUID = 6482445402768874493L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeConnectorKeyConfigException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeConnectorKeyConfigException.java
@@ -1,15 +1,15 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
 /**
  * Thrown if the configured connection key is unavailable.
  */
-@DefaultAnnotation(NonNull.class)
+@SuppressWarnings("unused")
+@NullMarked
 public class GCFacadeConnectorKeyConfigException extends GCFacadeConfigException {
   @Serial
   private static final long serialVersionUID = -4124879618192150569L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeException.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
@@ -10,7 +9,7 @@ import java.io.Serial;
  * Base failure for any exceptions raised by this facade.
  */
 @SuppressWarnings("WeakerAccess")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class GCFacadeException extends RuntimeException {
   @Serial
   private static final long serialVersionUID = 8255693835569503552L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeFileTypeConfigException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeFileTypeConfigException.java
@@ -1,15 +1,15 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
 /**
  * Thrown if the configured file type is not supported by GlobalLink.
  */
-@DefaultAnnotation(NonNull.class)
+@SuppressWarnings("unused")
+@NullMarked
 public class GCFacadeFileTypeConfigException extends GCFacadeConfigException {
   @Serial
   private static final long serialVersionUID = 2180398367798706948L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeIOException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeIOException.java
@@ -1,8 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
@@ -10,7 +9,7 @@ import java.io.Serial;
  * Signals some local IO failure.
  */
 @SuppressWarnings("unused")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class GCFacadeIOException extends GCFacadeException {
   @Serial
   private static final long serialVersionUID = 8022138209281797363L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeSubmissionException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeSubmissionException.java
@@ -1,12 +1,14 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
 /**
  * Signals an issue with a submission at GlobalLink.
  */
+@NullMarked
 public class GCFacadeSubmissionException extends GCFacadeException {
   @Serial
   private static final long serialVersionUID = 3746655613283049534L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeSubmissionNotFoundException.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCFacadeSubmissionNotFoundException.java
@@ -1,12 +1,15 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 
 /**
  * Signals that a submission was not found at GlobalLink.
  */
+@SuppressWarnings("unused")
+@NullMarked
 public class GCFacadeSubmissionNotFoundException extends GCFacadeSubmissionException {
   @Serial
   private static final long serialVersionUID = 7381206719419170238L;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCSubmissionModel.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCSubmissionModel.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -13,13 +13,11 @@ import static java.lang.invoke.MethodHandles.lookup;
 /**
  * Model to store the data of a Submission returned by the GCC-Client.
  */
+@NullMarked
 public class GCSubmissionModel {
   private final long submissionId;
-  @NonNull
   private final List<String> pdSubmissionIds;
-  @NonNull
   private final String name;
-  @NonNull
   private final GCSubmissionState state;
   @Nullable
   private final String submitter;
@@ -47,7 +45,7 @@ public class GCSubmissionModel {
    * @deprecated Use {@link #builder(long)} instead.
    */
   @Deprecated(since = "2401.3")
-  public GCSubmissionModel(long submissionId, @NonNull Collection<String> pdSubmissionIds, @NonNull GCSubmissionState state) {
+  public GCSubmissionModel(long submissionId, Collection<String> pdSubmissionIds, GCSubmissionState state) {
     this(submissionId, pdSubmissionIds, "", state, null, false);
   }
 
@@ -62,9 +60,9 @@ public class GCSubmissionModel {
    * @param error           if the submission is in an error state
    */
   private GCSubmissionModel(long submissionId,
-                            @NonNull Collection<String> pdSubmissionIds,
-                            @NonNull String name,
-                            @NonNull GCSubmissionState state,
+                            Collection<String> pdSubmissionIds,
+                            String name,
+                            GCSubmissionState state,
                             @Nullable String submitter,
                             boolean error) {
     this.submissionId = submissionId;
@@ -79,22 +77,18 @@ public class GCSubmissionModel {
     return submissionId;
   }
 
-  @NonNull
   public List<String> getPdSubmissionIds() {
     return pdSubmissionIds;
   }
 
-  @NonNull
   public String getName() {
     return name;
   }
 
-  @NonNull
   public GCSubmissionState getState() {
     return state;
   }
 
-  @NonNull
   public Optional<String> findSubmitter() {
     return Optional.ofNullable(submitter);
   }
@@ -106,7 +100,6 @@ public class GCSubmissionModel {
     return error;
   }
 
-  @NonNull
   public String describe() {
     return "%s[error=%s, name=%s, pdSubmissionIds=%s, state=%s, submissionId=%s, submitter=%s]".formatted(
       lookup().lookupClass().getSimpleName(),
@@ -153,14 +146,11 @@ public class GCSubmissionModel {
    */
   public static final class Builder {
     private final long submissionId;
-    @NonNull
     private List<String> pdSubmissionIds = List.of();
-    @NonNull
     private GCSubmissionState state = GCSubmissionState.OTHER;
     @Nullable
     private String submitter;
     private boolean error;
-    @NonNull
     private String name = "";
 
     private Builder(long submissionId) {
@@ -173,8 +163,7 @@ public class GCSubmissionModel {
      * @param pdSubmissionIds Project-Director Submission IDs
      * @return self-reference
      */
-    @NonNull
-    public Builder pdSubmissionIds(@NonNull Collection<String> pdSubmissionIds) {
+    public Builder pdSubmissionIds(Collection<String> pdSubmissionIds) {
       this.pdSubmissionIds = List.copyOf(pdSubmissionIds);
       return this;
     }
@@ -185,8 +174,7 @@ public class GCSubmissionModel {
      * @param state submission state
      * @return self-reference
      */
-    @NonNull
-    public Builder state(@NonNull GCSubmissionState state) {
+    public Builder state(GCSubmissionState state) {
       this.state = Objects.requireNonNull(state);
       return this;
     }
@@ -197,7 +185,6 @@ public class GCSubmissionModel {
      * @param submitter name
      * @return self-reference
      */
-    @NonNull
     public Builder submitter(@Nullable String submitter) {
       this.submitter = submitter;
       return this;
@@ -209,7 +196,6 @@ public class GCSubmissionModel {
      * @param name name
      * @return self-reference
      */
-    @NonNull
     public Builder name(String name) {
       this.name = name;
       return this;
@@ -221,7 +207,6 @@ public class GCSubmissionModel {
      * @param error state
      * @return self-reference
      */
-    @NonNull
     public Builder error(boolean error) {
       this.error = error;
       return this;
@@ -232,7 +217,6 @@ public class GCSubmissionModel {
      *
      * @return model
      */
-    @NonNull
     public GCSubmissionModel build() {
       return new GCSubmissionModel(submissionId, pdSubmissionIds, name, state, submitter, error);
     }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCSubmissionState.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/GCSubmissionState.java
@@ -1,10 +1,9 @@
 package com.coremedia.labs.translation.gcc.facade;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gs4tr.gcc.restclient.model.Status;
 import org.gs4tr.gcc.restclient.model.SubmissionStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
@@ -28,7 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * @see SubmissionStatus
  */
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public enum GCSubmissionState {
 
   /*
@@ -103,7 +102,7 @@ public enum GCSubmissionState {
     submissionStatusText = null;
   }
 
-  GCSubmissionState(@NonNull SubmissionStatus submissionStatus) {
+  GCSubmissionState(SubmissionStatus submissionStatus) {
     submissionStatusText = submissionStatus.text();
   }
 
@@ -113,7 +112,7 @@ public enum GCSubmissionState {
    *
    * @param submissionStatusText text
    */
-  GCSubmissionState(@NonNull String submissionStatusText) {
+  GCSubmissionState(String submissionStatusText) {
     this.submissionStatusText = submissionStatusText;
   }
 
@@ -150,8 +149,7 @@ public enum GCSubmissionState {
    * @param statusName name to parse
    * @return status; {@link #OTHER} for any yet unknown status
    */
-  @NonNull
-  public static Optional<GCSubmissionState> findSubmissionStateByName(@NonNull String statusName) {
+  public static Optional<GCSubmissionState> findSubmissionStateByName(String statusName) {
     return Arrays.stream(values())
       .filter(s -> nonNull(s.submissionStatusText))
       .filter(s -> statusName.equalsIgnoreCase(s.submissionStatusText))

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/CharacterReplacementStrategy.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/CharacterReplacementStrategy.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Optional;
@@ -16,6 +16,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * @since 2406.1
  */
+@NullMarked
 public enum CharacterReplacementStrategy {
   /**
    * Do not apply any replacement.
@@ -48,18 +49,15 @@ public enum CharacterReplacementStrategy {
 
   private static final Logger LOG = getLogger(lookup().lookupClass());
 
-  @NonNull
   private final String id;
 
-  @NonNull
   private final Function<MatchResult, String> replacer;
 
-  CharacterReplacementStrategy(@NonNull Function<MatchResult, String> replacer) {
+  CharacterReplacementStrategy(Function<MatchResult, String> replacer) {
     id = stripUnderscoresAndDashes(name());
     this.replacer = replacer;
   }
 
-  @NonNull
   public Function<MatchResult, String> replacer() {
     return replacer;
   }
@@ -86,7 +84,6 @@ public enum CharacterReplacementStrategy {
     return Optional.empty();
   }
 
-  @NonNull
   public static Optional<CharacterReplacementStrategy> fromString(@Nullable String strategy) {
     if (strategy == null || strategy.isBlank()) {
       LOG.trace("No replacement-strategy given. Returning empty.");
@@ -102,8 +99,7 @@ public enum CharacterReplacementStrategy {
     return Optional.empty();
   }
 
-  @NonNull
-  private static String replaceIfNotEmpty(@NonNull MatchResult mr, @NonNull String replacement) {
+  private static String replaceIfNotEmpty(MatchResult mr, String replacement) {
     return mr.group().isEmpty() ? "" : replacement;
   }
 
@@ -113,8 +109,7 @@ public enum CharacterReplacementStrategy {
    * @param str string to strip underscores and dashes from
    * @return string without underscores and dashes
    */
-  @NonNull
-  private static String stripUnderscoresAndDashes(@NonNull String str) {
+  private static String stripUnderscoresAndDashes(String str) {
     return str.replace("_", "").replace("-", "");
   }
 }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/CharacterType.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/CharacterType.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Optional;
@@ -25,6 +25,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * @since 2406.1
  */
+@NullMarked
 public enum CharacterType {
   /**
    * Only characters from the Basic Multilingual Plane (BMP) are supported.
@@ -33,8 +34,8 @@ public enum CharacterType {
     private static final Pattern HIGHER_UNICODE_CHARACTERS = Pattern.compile("[^\\x00-\\uffff]");
 
     @Override
-    public String replaceAllInvalid(@NonNull String value,
-                                    @NonNull Function<MatchResult, String> replacer) {
+    public String replaceAllInvalid(String value,
+                                    Function<MatchResult, String> replacer) {
       return HIGHER_UNICODE_CHARACTERS
         .matcher(value)
         .replaceAll(replacer);
@@ -52,8 +53,8 @@ public enum CharacterType {
      * @return the value as is
      */
     @Override
-    public String replaceAllInvalid(@NonNull String value,
-                                    @NonNull Function<MatchResult, String> replacer) {
+    public String replaceAllInvalid(String value,
+                                    Function<MatchResult, String> replacer) {
       return value;
     }
   },
@@ -69,7 +70,7 @@ public enum CharacterType {
    * @param replacer the function to replace invalid characters
    * @return the value with all invalid characters replaced
    */
-  public abstract String replaceAllInvalid(@NonNull String value, @NonNull Function<MatchResult, String> replacer);
+  public abstract String replaceAllInvalid(String value, Function<MatchResult, String> replacer);
 
   /**
    * Returns the type for the given configuration object.
@@ -99,7 +100,6 @@ public enum CharacterType {
    * @param type type as string
    * @return the parsed type, or empty if the type is unknown/not set
    */
-  @NonNull
   public static Optional<CharacterType> fromString(@Nullable String type) {
     if (type == null || type.isBlank()) {
       LOG.trace("No supported character-type given. Returning empty.");

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/GCSubmissionInstruction.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/GCSubmissionInstruction.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
 import com.coremedia.labs.translation.gcc.facade.GCConfigProperty;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 
 import java.util.Map;
@@ -25,6 +25,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @see CharacterReplacementStrategy
  * @since 2406.1
  */
+@NullMarked
 public final class GCSubmissionInstruction {
   private static final Logger LOG = getLogger(lookup().lookupClass());
   private static final String CONFIG_KEY = GCConfigProperty.KEY_SUBMISSION_INSTRUCTION;
@@ -66,17 +67,13 @@ public final class GCSubmissionInstruction {
    *   <li>{@code textTransform}: {@link TextTransform#TEXT_TO_HTML}</li>
    * </ul>
    */
-  @NonNull
   public static final GCSubmissionInstruction DEFAULT = new GCSubmissionInstruction(
     DEFAULT_SUPPORTED_CHARACTER_TYPE,
     DEFAULT_CHARACTER_REPLACEMENT_STRATEGY,
     DEFAULT_TEXT_TYPE
   );
-  @NonNull
   private final CharacterType characterType;
-  @NonNull
   private final CharacterReplacementStrategy characterReplacementStrategy;
-  @NonNull
   private final TextTransform textTransform;
 
   /**
@@ -86,9 +83,9 @@ public final class GCSubmissionInstruction {
    * @param characterReplacementStrategy strategy for replacing invalid characters
    * @param textTransform                     the default text type
    */
-  private GCSubmissionInstruction(@NonNull CharacterType characterType,
-                                  @NonNull CharacterReplacementStrategy characterReplacementStrategy,
-                                  @NonNull TextTransform textTransform) {
+  private GCSubmissionInstruction(CharacterType characterType,
+                                  CharacterReplacementStrategy characterReplacementStrategy,
+                                  TextTransform textTransform) {
     this.characterType = characterType;
     this.characterReplacementStrategy = characterReplacementStrategy;
     this.textTransform = textTransform;
@@ -100,8 +97,7 @@ public final class GCSubmissionInstruction {
    * @param value the value to transform
    * @return the transformed value
    */
-  @NonNull
-  public String transformText(@NonNull String value) {
+  public String transformText(String value) {
     String transformedCharacters = characterType.replaceAllInvalid(value, characterReplacementStrategy.replacer());
     String transformedText = textTransform.transform(transformedCharacters);
     if (LOG.isDebugEnabled() && !value.equals(transformedText)) {
@@ -117,8 +113,7 @@ public final class GCSubmissionInstruction {
    * @param config the {@code globalLink} configuration
    * @return the configuration for submission names
    */
-  @NonNull
-  public static GCSubmissionInstruction fromGlobalLinkConfig(@NonNull Map<String, ?> config) {
+  public static GCSubmissionInstruction fromGlobalLinkConfig(Map<String, ?> config) {
     Object configObject = config.get(CONFIG_KEY);
     if (configObject instanceof GCSubmissionInstruction submissionInstruction) {
       return submissionInstruction;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/GCSubmissionName.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/GCSubmissionName.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
 import com.coremedia.labs.translation.gcc.facade.GCConfigProperty;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 
 import java.util.Map;
@@ -25,6 +25,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @see CharacterReplacementStrategy
  * @since 2406.1
  */
+@NullMarked
 public final class GCSubmissionName {
   private static final Logger LOG = getLogger(lookup().lookupClass());
   private static final String CONFIG_KEY = GCConfigProperty.KEY_SUBMISSION_NAME;
@@ -47,11 +48,8 @@ public final class GCSubmissionName {
    *   <li>{@code characterReplacementStrategy}: {@link CharacterReplacementStrategy#UNDERSCORE}</li>
    * </ul>
    */
-  @NonNull
   public static final GCSubmissionName DEFAULT = new GCSubmissionName(DEFAULT_SUPPORTED_CHARACTER_TYPE, DEFAULT_CHARACTER_REPLACEMENT_STRATEGY);
-  @NonNull
   private final CharacterType characterType;
-  @NonNull
   private final CharacterReplacementStrategy characterReplacementStrategy;
 
   /**
@@ -60,8 +58,8 @@ public final class GCSubmissionName {
    * @param characterType                type of supported characters
    * @param characterReplacementStrategy strategy for replacing invalid characters
    */
-  private GCSubmissionName(@NonNull CharacterType characterType,
-                           @NonNull CharacterReplacementStrategy characterReplacementStrategy) {
+  private GCSubmissionName(CharacterType characterType,
+                           CharacterReplacementStrategy characterReplacementStrategy) {
     this.characterType = characterType;
     this.characterReplacementStrategy = characterReplacementStrategy;
   }
@@ -72,8 +70,7 @@ public final class GCSubmissionName {
    * @param value the value to transform
    * @return the transformed value
    */
-  @NonNull
-  public String transform(@NonNull String value) {
+  public String transform(String value) {
     String trimmed = value.trim();
     String transformed = characterType.replaceAllInvalid(trimmed, characterReplacementStrategy.replacer());
     String truncated = truncate(transformed);
@@ -89,8 +86,7 @@ public final class GCSubmissionName {
    * @param value the value to truncate
    * @return the truncated value
    */
-  @NonNull
-  private static String truncate(@NonNull String value) {
+  private static String truncate(String value) {
     return value.substring(0, Math.min(value.length(), DEFAULT_MAX_LENGTH));
   }
 
@@ -101,8 +97,7 @@ public final class GCSubmissionName {
    * @param config the {@code globalLink} configuration
    * @return the configuration for submission names
    */
-  @NonNull
-  public static GCSubmissionName fromGlobalLinkConfig(@NonNull Map<String, ?> config) {
+  public static GCSubmissionName fromGlobalLinkConfig(Map<String, ?> config) {
     Object configObject = config.get(CONFIG_KEY);
     if (configObject instanceof GCSubmissionName submissionName) {
       return submissionName;

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/TextTransform.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/main/java/com/coremedia/labs/translation/gcc/facade/config/TextTransform.java
@@ -1,7 +1,7 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Optional;
@@ -19,6 +19,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * @since 2406.1
  */
+@NullMarked
 public enum TextTransform {
   /**
    * No transformation. Take as is.
@@ -43,8 +44,7 @@ public enum TextTransform {
      * @return the transformed text
      */
     @Override
-    @NonNull
-    public String transform(@NonNull String text) {
+    public String transform(String text) {
       String result = text
         .replace("&", "&amp;")
         .replace("<", "&lt;")
@@ -61,7 +61,6 @@ public enum TextTransform {
   ;
 
   private static final Logger LOG = getLogger(lookup().lookupClass());
-  @NonNull
   private final String id;
 
   TextTransform() {
@@ -74,8 +73,7 @@ public enum TextTransform {
    * @param text the text to transform
    * @return the transformed text
    */
-  @NonNull
-  public String transform(@NonNull String text) {
+  public String transform(String text) {
     return text;
   }
 
@@ -108,7 +106,6 @@ public enum TextTransform {
    * @return the parsed type
    * set
    */
-  @NonNull
   public static Optional<TextTransform> fromString(@Nullable String type) {
     if (type == null || type.isBlank()) {
       LOG.debug("Empty transformation type. Returning empty.");
@@ -130,8 +127,7 @@ public enum TextTransform {
    * @param str string to strip underscores and dashes from
    * @return string without underscores and dashes
    */
-  @NonNull
-  private static String stripUnderscoresAndDashes(@NonNull String str) {
+  private static String stripUnderscoresAndDashes(String str) {
     return str.replace("_", "").replace("-", "");
   }
 }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/CharacterReplacementStrategyTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/CharacterReplacementStrategyTest.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,13 +21,14 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@NullMarked
 class CharacterReplacementStrategyTest {
   @Nested
   @DisplayName("replacer():Function<MatchResult,String>")
   class MethodReplacer {
     @ParameterizedTest
     @EnumSource(CharacterReplacementStrategy.class)
-    void shouldReturnReplacerFunction(@NonNull CharacterReplacementStrategy input) {
+    void shouldReturnReplacerFunction(CharacterReplacementStrategy input) {
       assertThat(input.replacer()).isNotNull();
     }
 
@@ -37,7 +38,7 @@ class CharacterReplacementStrategyTest {
       mode = EnumSource.Mode.EXCLUDE,
       names = {"NONE", "EMPTY"}
     )
-    void shouldReplaceSomething(@NonNull CharacterReplacementStrategy input) {
+    void shouldReplaceSomething(CharacterReplacementStrategy input) {
       Function<MatchResult, String> replacer = input.replacer();
       String originalString = "a";
       Matcher matcher = PatternFixture.ANY_CHAR.matcher(originalString);
@@ -53,7 +54,7 @@ class CharacterReplacementStrategyTest {
       mode = EnumSource.Mode.EXCLUDE,
       names = {"NONE", "EMPTY"}
     )
-    void shouldNotReplaceEmptyMatch(@NonNull CharacterReplacementStrategy input) {
+    void shouldNotReplaceEmptyMatch(CharacterReplacementStrategy input) {
       Function<MatchResult, String> replacer = input.replacer();
       String originalString = "";
       Matcher matcher = PatternFixture.ANY.matcher(originalString);
@@ -92,10 +93,10 @@ class CharacterReplacementStrategyTest {
       UNICODE_CODE_POINT | ANY_CHAR | 'a'                | 'U+0061'
       UNICODE_CODE_POINT | SMP      | 'a\uD83D\uDD4A'    | 'aU+1F54A'
       """)
-    void shouldApplyReplacementsAsExpected(@NonNull CharacterReplacementStrategy strategy,
-                                           @NonNull PatternFixture patternFixture,
-                                           @NonNull String input,
-                                           @NonNull String expected) {
+    void shouldApplyReplacementsAsExpected(CharacterReplacementStrategy strategy,
+                                           PatternFixture patternFixture,
+                                           String input,
+                                           String expected) {
       Function<MatchResult, String> replacer = strategy.replacer();
       Matcher matcher = patternFixture.matcher(input);
       String result = matcher.replaceAll(replacer);
@@ -110,7 +111,7 @@ class CharacterReplacementStrategyTest {
     class FromString {
       @ParameterizedTest
       @ArgumentsSource(ConfigTestCaseFixtureProvider.class)
-      void shouldParseValues(@NonNull CharacterReplacementStrategy expected, @NonNull String configValue) {
+      void shouldParseValues(CharacterReplacementStrategy expected, String configValue) {
         assertThat(CharacterReplacementStrategy.fromString(configValue)).hasValue(expected);
       }
 
@@ -129,7 +130,7 @@ class CharacterReplacementStrategyTest {
     class FromConfig {
       @ParameterizedTest
       @ArgumentsSource(ConfigTestCaseFixtureProvider.class)
-      void shouldParseValues(@NonNull CharacterReplacementStrategy expected, @NonNull String configValue) {
+      void shouldParseValues(CharacterReplacementStrategy expected, String configValue) {
         assertThat(CharacterReplacementStrategy.fromConfig(configValue)).hasValue(expected);
       }
 
@@ -145,7 +146,7 @@ class CharacterReplacementStrategyTest {
 
       @ParameterizedTest
       @EnumSource(CharacterReplacementStrategy.class)
-      void shouldReturnEnumAsIs(@NonNull CharacterReplacementStrategy input) {
+      void shouldReturnEnumAsIs(CharacterReplacementStrategy input) {
         CharacterReplacementStrategy actual = CharacterReplacementStrategy.fromConfig(input).orElse(null);
         assertThat(actual).isEqualTo(input);
       }
@@ -160,25 +161,19 @@ class CharacterReplacementStrategyTest {
 
     private final Pattern pattern;
 
-    PatternFixture(@NonNull Pattern pattern) {
+    PatternFixture(Pattern pattern) {
       this.pattern = pattern;
     }
 
-    @NonNull
-    public Pattern pattern() {
-      return pattern;
-    }
-
-    @NonNull
-    public Matcher matcher(@NonNull CharSequence input) {
+    public Matcher matcher(CharSequence input) {
       return pattern.matcher(input);
     }
   }
 
   static class ConfigTestCaseFixtureProvider implements ArgumentsProvider {
     @Override
-    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
-                                                                 @NonNull ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters,
+                                                        ExtensionContext context) {
       return EnumConfigValueFixture.provideArguments(CharacterReplacementStrategy.values());
     }
   }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/CharacterTypeTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/CharacterTypeTest.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@NullMarked
 class CharacterTypeTest {
   @Nested
   class MethodReplaceAllInvalid {
@@ -41,7 +42,7 @@ class CharacterTypeTest {
     class FromString {
       @ParameterizedTest
       @ArgumentsSource(ConfigTestCaseFixtureProvider.class)
-      void shouldParseValues(@NonNull CharacterType expected, @NonNull String configValue) {
+      void shouldParseValues(CharacterType expected, String configValue) {
         assertThat(CharacterType.fromString(configValue)).hasValue(expected);
       }
 
@@ -60,7 +61,7 @@ class CharacterTypeTest {
     class FromConfig {
       @ParameterizedTest
       @ArgumentsSource(ConfigTestCaseFixtureProvider.class)
-      void shouldParseValues(@NonNull CharacterType expected, @NonNull String configValue) {
+      void shouldParseValues(CharacterType expected, String configValue) {
         assertThat(CharacterType.fromConfig(configValue)).hasValue(expected);
       }
 
@@ -76,7 +77,7 @@ class CharacterTypeTest {
 
       @ParameterizedTest
       @EnumSource(CharacterType.class)
-      void shouldReturnEnumAsIs(@NonNull CharacterType input) {
+      void shouldReturnEnumAsIs(CharacterType input) {
         CharacterType actual = CharacterType.fromConfig(input).orElse(null);
         assertThat(actual).isEqualTo(input);
       }
@@ -85,8 +86,8 @@ class CharacterTypeTest {
 
   static class ConfigTestCaseFixtureProvider implements ArgumentsProvider {
     @Override
-    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
-                                                                 @NonNull ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters,
+                                                        ExtensionContext context) {
       return EnumConfigValueFixture.provideArguments(CharacterType.values());
     }
   }

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/EnumConfigValueFixture.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/EnumConfigValueFixture.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.Locale;
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+@NullMarked
 enum EnumConfigValueFixture {
   NAME(Enum::name),
   LOWER_CASE(en -> en.name().toLowerCase(Locale.ROOT)),
@@ -21,20 +22,17 @@ enum EnumConfigValueFixture {
   KEBAP_CASE(en -> en.name().toLowerCase(Locale.ROOT).replace('_', '-')),
   ;
 
-  @NonNull
   private final Function<Enum<?>, String> toConfigValue;
 
-  EnumConfigValueFixture(@NonNull Function<Enum<?>, String> toConfigValue) {
+  EnumConfigValueFixture(Function<Enum<?>, String> toConfigValue) {
     this.toConfigValue = toConfigValue;
   }
 
-  @NonNull
-  public String toConfigValue(@NonNull Enum<?> transform) {
+  public String toConfigValue(Enum<?> transform) {
     return toConfigValue.apply(transform);
   }
 
-  @NonNull
-  public static Stream<? extends Arguments> provideArguments(@NonNull Enum<?>[] enumType) {
+  public static Stream<? extends Arguments> provideArguments(Enum<?>[] enumType) {
     return java.util.stream.Stream.of(enumType)
       .flatMap(en -> java.util.stream.Stream.of(values())
         .map(testCaseFixture -> Arguments.of(en, testCaseFixture.toConfigValue(en))));

--- a/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/TextTransformTest.java
+++ b/apps/workflow-server/gcc-workflow-server-facade/gcc-restclient-facade/src/test/java/com/coremedia/labs/translation/gcc/facade/config/TextTransformTest.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.translation.gcc.facade.config;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import static com.coremedia.labs.translation.gcc.facade.config.TextTransform.TEXT_TO_HTML;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@NullMarked
 class TextTransformTest {
   @Nested
   class MethodTransform {
@@ -25,7 +26,7 @@ class TextTransformTest {
       @ParameterizedTest
       @DisplayName("textToHtml: Text should be transformed to HTML")
       @EnumSource(TextToHtmlFixture.class)
-      void shouldTransformTextToHtml(@NonNull TextToHtmlFixture fixture) {
+      void shouldTransformTextToHtml(TextToHtmlFixture fixture) {
         String actual = TEXT_TO_HTML.transform(fixture.input());
         assertThat(actual).isEqualTo(fixture.expectedOutput());
       }
@@ -36,7 +37,7 @@ class TextTransformTest {
       @ParameterizedTest
       @DisplayName("none: Text should not be transformed")
       @EnumSource(TextToHtmlFixture.class)
-      void shouldNotTransformText(@NonNull TextToHtmlFixture fixture) {
+      void shouldNotTransformText(TextToHtmlFixture fixture) {
         String actual = TextTransform.NONE.transform(fixture.input());
         assertThat(actual).isEqualTo(fixture.input());
       }
@@ -50,7 +51,7 @@ class TextTransformTest {
     class FromString {
       @ParameterizedTest
       @ArgumentsSource(ConfigTestCaseFixtureProvider.class)
-      void shouldParseValues(@NonNull TextTransform expected, @NonNull String configValue) {
+      void shouldParseValues(TextTransform expected, String configValue) {
         assertThat(TextTransform.fromString(configValue)).hasValue(expected);
       }
 
@@ -69,7 +70,7 @@ class TextTransformTest {
     class FromConfig {
       @ParameterizedTest
       @ArgumentsSource(ConfigTestCaseFixtureProvider.class)
-      void shouldParseValues(@NonNull TextTransform expected, @NonNull String configValue) {
+      void shouldParseValues(TextTransform expected, String configValue) {
         assertThat(TextTransform.fromConfig(configValue)).hasValue(expected);
       }
 
@@ -85,7 +86,7 @@ class TextTransformTest {
 
       @ParameterizedTest
       @EnumSource(TextTransform.class)
-      void shouldReturnEnumAsIs(@NonNull TextTransform input) {
+      void shouldReturnEnumAsIs(TextTransform input) {
         TextTransform actual = TextTransform.fromConfig(input).orElse(null);
         assertThat(actual).isEqualTo(input);
       }
@@ -94,8 +95,8 @@ class TextTransformTest {
 
   static class ConfigTestCaseFixtureProvider implements ArgumentsProvider {
     @Override
-    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
-                                                                 @NonNull ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters,
+                                                        ExtensionContext context) {
       return EnumConfigValueFixture.provideArguments(TextTransform.values());
     }
   }

--- a/apps/workflow-server/gcc-workflow-server-util/pom.xml
+++ b/apps/workflow-server/gcc-workflow-server-util/pom.xml
@@ -46,11 +46,6 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/apps/workflow-server/gcc-workflow-server-util/src/main/java/com/coremedia/labs/translation/gcc/util/Settings.java
+++ b/apps/workflow-server/gcc-workflow-server-util/src/main/java/com/coremedia/labs/translation/gcc/util/Settings.java
@@ -3,8 +3,8 @@ package com.coremedia.labs.translation.gcc.util;
 import com.coremedia.cap.content.ContentRepository;
 import com.coremedia.cap.multisite.Site;
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.UnknownNullness;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.BeanFactory;
 
@@ -423,8 +423,8 @@ public record Settings(Map<String, Object> properties) {
    * @param depth the current nesting depth
    * @return a sanitized value with filtered entries if it is a map
    */
-  @UnknownNullness
-  private static Object sanitizeValue(@UnknownNullness Object value, int depth) {
+  @NullUnmarked
+  private static Object sanitizeValue(Object value, int depth) {
     if (value instanceof Map<?, ?> map) {
       if (depth >= MAX_DEPTH) {
         LOG.warn("Depth limit ({}) exceeded. Truncating nested structure.", MAX_DEPTH);
@@ -483,7 +483,8 @@ public record Settings(Map<String, Object> properties) {
    * @return {@code true} if the key is a non-null string; {@code false}
    * otherwise
    */
-  private static boolean considerKey(@UnknownNullness Object value) {
+  @NullUnmarked
+  private static boolean considerKey(Object value) {
     return value instanceof String;
   }
 
@@ -497,7 +498,8 @@ public record Settings(Map<String, Object> properties) {
    * @param value the value to validate
    * @return {@code true} if the value should be included; {@code false} otherwise
    */
-  private static boolean considerValue(@UnknownNullness Object value) {
+  @NullUnmarked
+  private static boolean considerValue(Object value) {
     if (value == null) {
       return false;
     }

--- a/apps/workflow-server/gcc-workflow-server-util/src/main/java/com/coremedia/labs/translation/gcc/util/SettingsSource.java
+++ b/apps/workflow-server/gcc-workflow-server-util/src/main/java/com/coremedia/labs/translation/gcc/util/SettingsSource.java
@@ -7,8 +7,8 @@ import com.coremedia.cap.content.ContentRepository;
 import com.coremedia.cap.content.ContentType;
 import com.coremedia.cap.multisite.Site;
 import com.coremedia.cap.struct.Struct;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.BeanFactory;
 

--- a/apps/workflow-server/gcc-workflow-server-util/src/main/java/com/coremedia/labs/translation/gcc/util/Zipper.java
+++ b/apps/workflow-server/gcc-workflow-server-util/src/main/java/com/coremedia/labs/translation/gcc/util/Zipper.java
@@ -1,10 +1,10 @@
 package com.coremedia.labs.translation.gcc.util;
 
 import com.google.common.io.ByteStreams;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,12 +22,14 @@ import java.util.zip.ZipOutputStream;
 /**
  * One-call zip and unzip convenience
  */
+@NullMarked
 public final class Zipper {
   private static final Logger LOG = LoggerFactory.getLogger(Zipper.class);
   private static final String TMPFILE_PREFIX = "gcczipper";
 
   // static class
-  private Zipper() {}
+  private Zipper() {
+  }
 
 
   // --- features ---------------------------------------------------
@@ -38,10 +40,9 @@ public final class Zipper {
    * The invoker is responsible for deletion of the output directory.
    *
    * @param zipFile the zip file, URL or file path
-   * @param prefix extract only entries that start with this prefix (optional)
+   * @param prefix  extract only entries that start with this prefix (optional)
    * @return the output directory
    */
-  @NonNull
   public static File unzip(String zipFile, @Nullable String prefix) {
     File extractionDir = tempDir();
     try {
@@ -57,8 +58,8 @@ public final class Zipper {
    * Extracts the zip file into the target directory.
    *
    * @param targetDir the target directory
-   * @param zipFile the zip file, URL or file path
-   * @param prefix extract only entries that start with this prefix (optional)
+   * @param zipFile   the zip file, URL or file path
+   * @param prefix    extract only entries that start with this prefix (optional)
    */
   public static void unzip(File targetDir, String zipFile, @Nullable String prefix) {
     unzip(targetDir, new File(zipFile), prefix);
@@ -68,8 +69,8 @@ public final class Zipper {
    * Zip the source directory into the zip file.
    *
    * @param zipFile the zip file, writable URL or file path
-   * @param srcDir the directory to be zipped
-   * @param prefix include only entries that start with the prefix (optional)
+   * @param srcDir  the directory to be zipped
+   * @param prefix  include only entries that start with the prefix (optional)
    */
   public static void zip(String zipFile, File srcDir, @Nullable String prefix) {
     zip(new File(zipFile), srcDir, prefix);
@@ -85,7 +86,7 @@ public final class Zipper {
         if (PathUtil.isReferringToParent(entry.getName())) {
           throw new IllegalArgumentException(zipFile.getAbsolutePath() + " exploits the Zip Slip Vulnerability. Extraction aborted.");
         }
-        if (!entry.isDirectory() && (prefix==null || entry.getName().startsWith(prefix))) {
+        if (!entry.isDirectory() && (prefix == null || entry.getName().startsWith(prefix))) {
           File file = new File(targetDir, entry.getName());
           mkParentDirs(file);
           try (OutputStream fos = new FileOutputStream(file)) {
@@ -113,7 +114,7 @@ public final class Zipper {
     }
   }
 
-  private static void recZip(ZipOutputStream zos, File zipRoot, File file, File theZipFileItself, String prefix) throws IOException {
+  private static void recZip(ZipOutputStream zos, File zipRoot, File file, File theZipFileItself, @Nullable String prefix) throws IOException {
     if (file.isDirectory()) {
       File[] children = file.listFiles();
       if (children != null) {
@@ -123,7 +124,7 @@ public final class Zipper {
       }
     } else if (!file.equals(theZipFileItself)) {
       String name = zipEntryName(zipRoot, file);
-      if (prefix==null || name.startsWith(prefix)) {
+      if (prefix == null || name.startsWith(prefix)) {
         try (FileInputStream fis = new FileInputStream(file)) {
           zos.putNextEntry(new ZipEntry(name));
           IOUtils.copy(fis, zos);
@@ -167,7 +168,6 @@ public final class Zipper {
     }
   }
 
-  @NonNull
   private static File tempDir() {
     try {
       return Files.createTempDirectory(TMPFILE_PREFIX).toFile();

--- a/apps/workflow-server/gcc-workflow-server-util/src/test/java/com/coremedia/labs/translation/gcc/util/SettingsTest.java
+++ b/apps/workflow-server/gcc-workflow-server-util/src/test/java/com/coremedia/labs/translation/gcc/util/SettingsTest.java
@@ -1,8 +1,9 @@
 package com.coremedia.labs.translation.gcc.util;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -31,11 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringJUnitConfig(SettingsTest.LocalConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@NullMarked
 class SettingsTest {
-  @NonNull
   private final ApplicationContext context;
 
-  SettingsTest(@Autowired @NonNull ApplicationContext context) {
+  SettingsTest(@Autowired ApplicationContext context) {
     this.context = context;
   }
 
@@ -43,7 +44,7 @@ class SettingsTest {
   class EmptyBehavior {
     @ParameterizedTest
     @EnumSource(EmptyFixture.class)
-    void shouldHaveEmptyProperties(@NonNull EmptyFixture emptyFixture) {
+    void shouldHaveEmptyProperties(EmptyFixture emptyFixture) {
       Settings settings = emptyFixture.get();
       assertThat(settings)
         .extracting(Settings::properties, InstanceOfAssertFactories.map(String.class, Object.class))
@@ -53,28 +54,24 @@ class SettingsTest {
     enum EmptyFixture implements Supplier<Settings> {
       CONSTANT {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.EMPTY;
         }
       },
       OF_EMPTY_MAP {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.of(Map.of());
         }
       },
       BUILDER_WITHOUT_SOURCES {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.builder().build();
         }
       },
       BUILDER_WITH_EMPTY_SETTINGS_SOURCE {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.builder()
             .source(Settings.EMPTY)
@@ -83,7 +80,6 @@ class SettingsTest {
       },
       BUILDER_WITH_EMPTY_MAP_SOURCE {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.builder()
             .source(Map::of)
@@ -92,7 +88,6 @@ class SettingsTest {
       },
       BUILDER_WITH_EMPTY_SOURCES_LIST {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.builder()
             .sources(List.of())
@@ -101,7 +96,6 @@ class SettingsTest {
       },
       BUILDER_WITH_EMPTY_SOURCES_ARRAY {
         @Override
-        @NonNull
         public Settings get() {
           return Settings.builder()
             .sources()
@@ -115,10 +109,9 @@ class SettingsTest {
   @ParameterizedClass
   @EnumSource(SingleSourceBehavior.SingleSourceFixture.class)
   class SingleSourceBehavior {
-    @NonNull
     private final SingleSourceFixture fixture;
 
-    SingleSourceBehavior(@NonNull SingleSourceFixture fixture) {
+    SingleSourceBehavior(SingleSourceFixture fixture) {
       this.fixture = fixture;
     }
 
@@ -138,7 +131,7 @@ class SettingsTest {
     @ValueSource(longs = {Long.MIN_VALUE, Long.MAX_VALUE})
     @NullSource
     void shouldFilterOutMapsWithNonStringKeys(@Nullable Object key) {
-      Map<Object, Object> nestedInvalidMap = new HashMap<>();
+      Map<@Nullable Object, Object> nestedInvalidMap = new HashMap<>();
       nestedInvalidMap.put("valid_key", "value1");
       nestedInvalidMap.put(key, "value2");
       Map<String, Object> input = Map.of("containsInvalid", nestedInvalidMap);
@@ -153,7 +146,7 @@ class SettingsTest {
 
     @ParameterizedTest
     @EnumSource(EmptyValueFixture.class)
-    void shouldFilterEmptyValues(@NonNull EmptyValueFixture emptyValueFixture) {
+    void shouldFilterEmptyValues(EmptyValueFixture emptyValueFixture) {
       Map<String, Object> properties = new HashMap<>();
       properties.put("non-empty", "value");
       properties.put("empty", emptyValueFixture.get());
@@ -166,7 +159,7 @@ class SettingsTest {
 
     @ParameterizedTest
     @EnumSource(EmptyValueFixture.class)
-    void shouldFilterEmptyValuesDeeply(@NonNull EmptyValueFixture emptyValueFixture) {
+    void shouldFilterEmptyValuesDeeply(EmptyValueFixture emptyValueFixture) {
       Map<String, Object> onlyEmpty = new HashMap<>();
       Map<String, Object> alsoEmpty = new HashMap<>();
       onlyEmpty.put("empty", emptyValueFixture.get());
@@ -302,15 +295,13 @@ class SettingsTest {
     enum SingleSourceFixture implements Function<Map<String, Object>, Settings> {
       OF {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> map) {
+        public Settings apply(Map<String, Object> map) {
           return Settings.of(map);
         }
       },
       BUILDER_WITH_MAP_SOURCE {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> map) {
+        public Settings apply(Map<String, Object> map) {
           return Settings.builder()
             .source(() -> map)
             .build();
@@ -318,8 +309,7 @@ class SettingsTest {
       },
       BUILDER_WITH_SETTINGS_SOURCE {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> map) {
+        public Settings apply(Map<String, Object> map) {
           return Settings.builder()
             .source(Settings.of(map))
             .build();
@@ -327,8 +317,7 @@ class SettingsTest {
       },
       BUILDER_WITH_SOURCES_SINGLETON_LIST {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> map) {
+        public Settings apply(Map<String, Object> map) {
           return Settings.builder()
             .sources(List.of(() -> map))
             .build();
@@ -336,8 +325,7 @@ class SettingsTest {
       },
       BUILDER_WITH_SOURCES_SINGLETON_ARRAY {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> map) {
+        public Settings apply(Map<String, Object> map) {
           return Settings.builder()
             .sources(() -> map)
             .build();
@@ -350,10 +338,9 @@ class SettingsTest {
   @Nested
   @EnumSource(MultiSourceBehavior.MultiSource.class)
   class MultiSourceBehavior {
-    @NonNull
     private final MultiSource fixture;
 
-    MultiSourceBehavior(@NonNull MultiSource fixture) {
+    MultiSourceBehavior(MultiSource fixture) {
       this.fixture = fixture;
     }
 
@@ -395,7 +382,7 @@ class SettingsTest {
 
     @ParameterizedTest
     @EnumSource(EmptyValueFixture.class)
-    void shouldNotOverrideWithSecondSourceEmptyValue(@NonNull EmptyValueFixture emptyValueFixture) {
+    void shouldNotOverrideWithSecondSourceEmptyValue(EmptyValueFixture emptyValueFixture) {
       Map<String, Object> first = Map.of("key1", "value1", "to-override", "original");
       Map<String, Object> second = new HashMap<>(Map.of("key2", "value2"));
       second.put("to-override", emptyValueFixture.get());
@@ -421,7 +408,7 @@ class SettingsTest {
 
     @ParameterizedTest
     @EnumSource(EmptyValueFixture.class)
-    void shouldNotOverrideDeeplyWithSecondSourceEmptyValue(@NonNull EmptyValueFixture emptyValueFixture) {
+    void shouldNotOverrideDeeplyWithSecondSourceEmptyValue(EmptyValueFixture emptyValueFixture) {
       Map<String, Object> first = Map.of("parent", Map.of("to-override", "original"));
       Map<String, Object> emptyValue = new HashMap<>();
       emptyValue.put("to-override", emptyValueFixture.get());
@@ -497,8 +484,7 @@ class SettingsTest {
     enum MultiSource implements BiFunction<Map<String, Object>, Map<String, Object>, Settings> {
       BUILDER_WITH_MAP_SOURCES {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> first, @NonNull Map<String, Object> second) {
+        public Settings apply(Map<String, Object> first, Map<String, Object> second) {
           return Settings.builder()
             .source(() -> first)
             .source(() -> second)
@@ -507,8 +493,7 @@ class SettingsTest {
       },
       BUILDER_WITH_SOURCES_LIST {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> first, @NonNull Map<String, Object> second) {
+        public Settings apply(Map<String, Object> first, Map<String, Object> second) {
           return Settings.builder()
             .sources(List.of(() -> first, () -> second))
             .build();
@@ -516,8 +501,7 @@ class SettingsTest {
       },
       BUILDER_WITH_SOURCES_SINGLETON_ARRAY {
         @Override
-        @NonNull
-        public Settings apply(@NonNull Map<String, Object> first, @NonNull Map<String, Object> second) {
+        public Settings apply(Map<String, Object> first, Map<String, Object> second) {
           return Settings.builder()
             .sources(() -> first, () -> second)
             .build();
@@ -548,16 +532,15 @@ class SettingsTest {
   @ParameterizedClass
   @EnumSource(AtBehavior.AtVariant.class)
   class AtBehavior {
-    @NonNull
     private final AtVariant atVariant;
 
-    AtBehavior(@NonNull AtVariant atVariant) {
+    AtBehavior(AtVariant atVariant) {
       this.atVariant = atVariant;
     }
 
     @ParameterizedTest
     @EnumSource(SettingsFixture.class)
-    void shouldReturnEmptyIfNotFoundInDirectProperties(@NonNull SettingsFixture settingsFixture) {
+    void shouldReturnEmptyIfNotFoundInDirectProperties(SettingsFixture settingsFixture) {
       Settings settings = settingsFixture.get();
       Optional<Object> result = atVariant.apply(settings, List.of("unavailable"));
       assertThat(result).isEmpty();
@@ -565,7 +548,7 @@ class SettingsTest {
 
     @ParameterizedTest
     @EnumSource(SettingsFixture.class)
-    void shouldReturnEmptyIfNotFoundInNestedProperties(@NonNull SettingsFixture settingsFixture) {
+    void shouldReturnEmptyIfNotFoundInNestedProperties(SettingsFixture settingsFixture) {
       Settings settings = settingsFixture.get();
       Optional<Object> result = atVariant.apply(settings, List.of("key", "unavailable"));
       assertThat(result).isEmpty();
@@ -625,6 +608,7 @@ class SettingsTest {
     }
   }
 
+  @NullUnmarked
   enum EmptyValueFixture implements Supplier<Object> {
     NULL {
       @Override

--- a/apps/workflow-server/gcc-workflow-server/pom.xml
+++ b/apps/workflow-server/gcc-workflow-server/pom.xml
@@ -108,12 +108,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.coremedia.cms</groupId>
       <artifactId>cap-client-xml</artifactId>
       <scope>test</scope>

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/CancelTranslationGlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/CancelTranslationGlobalLinkAction.java
@@ -133,8 +133,9 @@ public class CancelTranslationGlobalLinkAction extends
   }
 
   @Override
-  void doExecuteGlobalLinkAction(Parameters params, Consumer<? super Result> resultConsumer,
+  void doExecuteGlobalLinkAction(@Nullable Parameters params, Consumer<? super Result> resultConsumer,
                                  GCExchangeFacade facade, Map<String, List<Content>> issues) {
+    requireNonNull(params, "Parameters must not be null.");
     long submissionId = params.submissionId;
     // Ignore Submission Error State: As we are trying to cancel the submission,
     // we don't care about the error state. At least for observed scenarios,

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/CancelTranslationGlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/CancelTranslationGlobalLinkAction.java
@@ -6,8 +6,8 @@ import com.coremedia.cap.workflow.Task;
 import com.coremedia.labs.translation.gcc.facade.GCExchangeFacade;
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionModel;
 import com.coremedia.labs.translation.gcc.facade.GCSubmissionState;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Workflow action that cancels a GlobalLink submission.
  */
+@NullMarked
 public class CancelTranslationGlobalLinkAction extends
         GlobalLinkAction<CancelTranslationGlobalLinkAction.Parameters, CancelTranslationGlobalLinkAction.Result> {
   @Serial
@@ -44,11 +45,11 @@ public class CancelTranslationGlobalLinkAction extends
 
   private static final int HTTP_OK = 200;
 
-  private String globalLinkSubmissionIdVariable;
-  private String globalLinkPdSubmissionIdsVariable;
-  private String globalLinkSubmissionStatusVariable;
-  private String cancelledVariable;
-  private String completedLocalesVariable;
+  private @Nullable String globalLinkSubmissionIdVariable;
+  private @Nullable String globalLinkPdSubmissionIdsVariable;
+  private @Nullable String globalLinkSubmissionStatusVariable;
+  private @Nullable String cancelledVariable;
+  private @Nullable String completedLocalesVariable;
 
   // --- construct and configure ------------------------------------
 
@@ -116,13 +117,11 @@ public class CancelTranslationGlobalLinkAction extends
   // --- GlobalLinkAction interface ----------------------------------------------------------------------
 
   @Override
-  @NonNull
   protected String getGCCRetryDelaySettingsKey() {
     return GCC_RETRY_DELAY_SETTINGS_KEY;
   }
 
   @Override
-  @NonNull
   Parameters doExtractParameters(Task task) {
     Process process = task.getContainingProcess();
     String submissionId = process.getString(globalLinkSubmissionIdVariable);

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/DownloadFromGlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/DownloadFromGlobalLinkAction.java
@@ -229,9 +229,10 @@ public class DownloadFromGlobalLinkAction extends GlobalLinkAction<DownloadFromG
   }
 
   @Override
-  void doExecuteGlobalLinkAction(Parameters params,
+  void doExecuteGlobalLinkAction(@Nullable Parameters params,
                                  Consumer<? super Result> resultConsumer,
                                  GCExchangeFacade facade, Map<String, List<Content>> issues) {
+    requireNonNull(params, "Parameters must not be null.");
     long submissionId = params.submissionId;
 
     // We need to share xliff files between #doExecuteGlobalLinkAction and #doStoreResult.

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
@@ -38,10 +38,10 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
-import edu.umd.cs.findbugs.annotations.UnknownNullness;
 import jakarta.activation.MimeType;
 import jakarta.activation.MimeTypeParseException;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.omg.CORBA.SystemException;
 import org.slf4j.Logger;
@@ -410,7 +410,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    */
   record AdaptDelayForGeneralRetryContext<P, R>(
     Settings settings,
-    @UnknownNullness P extendedParameters,
+    @NullUnmarked P extendedParameters,
     Optional<R> extendedResult,
     Map<String, List<Content>> issues
   ) {

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
@@ -40,6 +40,7 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import jakarta.activation.MimeType;
 import jakarta.activation.MimeTypeParseException;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
@@ -459,8 +460,8 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @return the parameters for the actual computation or {@code null} if no
    * parameters are needed
    */
-  @Nullable
-  abstract P doExtractParameters(Task task);
+  @NullUnmarked
+  abstract P doExtractParameters(@NonNull Task task);
 
   /**
    * Executes the action and optionally sets a result value at the given {@code resultConsumer}.
@@ -712,8 +713,9 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   }
 
   @VisibleForTesting
-  record Parameters<P>(@Nullable P extendedParameters,
-                       Collection<ContentObject> masterContentObjects,
+  @NullUnmarked
+  record Parameters<P>(P extendedParameters,
+                       @NonNull Collection<ContentObject> masterContentObjects,
                        int remainingAutomaticRetries) {
   }
 

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkAction.java
@@ -38,11 +38,11 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.UnknownNullness;
 import jakarta.activation.MimeType;
 import jakarta.activation.MimeTypeParseException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.omg.CORBA.SystemException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +93,7 @@ import static java.util.Objects.requireNonNull;
  * @param <R> the type of the result value that {@link #doExecuteGlobalLinkAction(Object, Consumer, GCExchangeFacade, Map)}
  *            passes to its consumer argument and that is then passed as parameter to {@link #doStoreResult(Task, Object)}
  */
+@NullMarked
 abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   private static final Logger LOG = LoggerFactory.getLogger(GlobalLinkAction.class);
 
@@ -145,11 +146,11 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
     CapErrorCodes.REPOSITORY_NOT_AVAILABLE
   );
 
-  private String skipVariable;
-  private String masterContentObjectsVariable;
-  private String remainingAutomaticRetriesVariable;
-  private String issuesVariable;
-  private String retryDelayTimerVariable;
+  private @Nullable String skipVariable;
+  private @Nullable String masterContentObjectsVariable;
+  private @Nullable String remainingAutomaticRetriesVariable;
+  private @Nullable String issuesVariable;
+  private @Nullable String retryDelayTimerVariable;
 
   // --- construct and configure ----------------------------------------------------------------------
 
@@ -174,7 +175,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @return the name of the process variable
    */
   String getMasterContentObjectsVariable() {
-    return masterContentObjectsVariable;
+    return requireNonNull(masterContentObjectsVariable, "masterContentObjectsVariable is null");
   }
 
   /**
@@ -225,7 +226,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   // --- LongAction interface ----------------------------------------------------------------------
 
   @Override
-  public final Parameters<P> extractParameters(Task task) {
+  public final @Nullable Parameters<P> extractParameters(Task task) {
     Process process = task.getContainingProcess();
 
     if (skipVariable != null && process.getBoolean(skipVariable)) {
@@ -255,9 +256,8 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @return parsed delay; a default when not available or failed parsing
    * the delay.
    */
-  @NonNull
-  private static RetryDelay getRetryDelay(@NonNull Settings settings,
-                                          @NonNull String key) {
+  private static RetryDelay getRetryDelay(Settings settings,
+                                          String key) {
     return findRetryDelay(settings, key).orElse(RetryDelay.DEFAULT);
   }
 
@@ -268,15 +268,14 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @param key      settings key where to expect the delay to read and parse
    * @return delay if found and valid; empty otherwise
    */
-  @NonNull
-  protected static Optional<RetryDelay> findRetryDelay(@NonNull Settings settings,
-                                                       @NonNull String key) {
+  protected static Optional<RetryDelay> findRetryDelay(Settings settings,
+                                                       String key) {
     return settings.at(key)
       .flatMap(RetryDelay::trySaturatedFromObject);
   }
 
   @Override
-  protected final Result<R> doExecute(Object params) {
+  protected final @Nullable Result<R> doExecute(@Nullable Object params) {
     if (params == null) {
       // skip
       return null;
@@ -334,8 +333,9 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
       LOG.warn("{}: Unknown error occurred ({})", getName(), GlobalLinkWorkflowErrorCodes.UNKNOWN_ERROR, e);
       issues.put(GlobalLinkWorkflowErrorCodes.UNKNOWN_ERROR, List.of());
     } catch (GlobalLinkWorkflowException e) {
-      LOG.warn("{}: {} ({})", getName(), e.getMessage(), e.getErrorCode(), e);
-      issues.put(e.getErrorCode(), List.of());
+      String errorCode = requireNonNull(e.getErrorCode(), () -> "Error code must be set but is unset: %s".formatted(e.getMessage()));
+      LOG.warn("{}: {} ({})", getName(), e.getMessage(), errorCode, e);
+      issues.put(errorCode, List.of());
     } catch (RuntimeException e) {
       // automatically retry upon CMS connection errors
       return getResultForCMSConnectionError(settings, e, result);
@@ -366,8 +366,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   // Since approvals around 2406.2.0-1 and 2506.0.0-1, keeping the pre-existing
   // state. We may later decide to just let the actions provide the delay
   // directly.
-  @NonNull
-  private RetryDelay getDefaultRetryDelay(@NonNull Settings settings) {
+  private RetryDelay getDefaultRetryDelay(Settings settings) {
     return getRetryDelay(settings, getGCCRetryDelaySettingsKey());
   }
 
@@ -390,9 +389,8 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @return adapted (or unchanged) retry delay
    * @see #getRetryDelay(Settings, String)
    */
-  @NonNull
-  RetryDelay adaptDelayForGeneralRetry(@NonNull RetryDelay originalRetryDelay,
-                                       @NonNull AdaptDelayForGeneralRetryContext<P, R> context) {
+  RetryDelay adaptDelayForGeneralRetry(RetryDelay originalRetryDelay,
+                                       AdaptDelayForGeneralRetryContext<P, R> context) {
     return originalRetryDelay;
   }
 
@@ -411,15 +409,15 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @param <R>                type of extended result
    */
   record AdaptDelayForGeneralRetryContext<P, R>(
-    @NonNull Settings settings,
+    Settings settings,
     @UnknownNullness P extendedParameters,
-    @NonNull Optional<R> extendedResult,
-    @NonNull Map<String, List<Content>> issues
+    Optional<R> extendedResult,
+    Map<String, List<Content>> issues
   ) {
   }
 
   @Override
-  public final ActionResult storeResult(Task task, Object result) {
+  public final ActionResult storeResult(Task task, @Nullable Object result) {
     checkNotAborted(task);
     if (result instanceof Exception) {
       return storeResultException(task, (Exception) result);
@@ -490,7 +488,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @throws GCFacadeException           if an error was raised by the given facade
    * @throws GlobalLinkWorkflowException if some other error occurred
    */
-  abstract void doExecuteGlobalLinkAction(P params,
+  abstract void doExecuteGlobalLinkAction(@Nullable P params,
                                           Consumer<? super R> resultConsumer,
                                           GCExchangeFacade facade,
                                           Map<String, List<Content>> issues);
@@ -523,7 +521,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
     return getSpringContext().getBean(SitesService.class);
   }
 
-  static long parseSubmissionId(String submissionId, String wfTaskId) {
+  static long parseSubmissionId(@Nullable String submissionId, String wfTaskId) {
     if (submissionId == null || submissionId.isEmpty()) {
       throw new GlobalLinkWorkflowException(GlobalLinkWorkflowErrorCodes.ILLEGAL_SUBMISSION_ID_ERROR, "GlobalLink submission id not set", wfTaskId);
     }
@@ -545,7 +543,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
 
   // --- Internal -------------------------------------------------------------
 
-  private Site getMasterSite(@NonNull Collection<? extends ContentObject> masterContents) {
+  private Site getMasterSite(Collection<? extends ContentObject> masterContents) {
     SitesService sitesService = getSitesService();
     return masterContents.stream()
       .map(sitesService::getSiteAspect)
@@ -555,7 +553,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
       .orElseThrow(() -> new IllegalStateException("No master site found"));
   }
 
-  private static int maxAutomaticRetries(@NonNull Settings settings) {
+  private static int maxAutomaticRetries(Settings settings) {
     return settings.at(CONFIG_RETRY_COMMUNICATION_ERRORS)
       .map(v -> {
         try {
@@ -568,17 +566,15 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
       .orElse(DEFAULT_RETRY_COMMUNICATION_ERRORS);
   }
 
-  @NonNull
-  private static Settings withContextSettings(@NonNull BeanFactory springContext) {
+  private static Settings withContextSettings(BeanFactory springContext) {
     return Settings.builder()
       .beanSource(springContext)
       .build();
   }
 
   @VisibleForTesting
-  @NonNull
-  Settings withGlobalSettings(@NonNull Settings base,
-                              @NonNull ContentRepository repository) {
+  Settings withGlobalSettings(Settings base,
+                              ContentRepository repository) {
     return Settings.builder()
       .source(base)
       .repositorySource(repository)
@@ -586,23 +582,20 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
   }
 
   @VisibleForTesting
-  @NonNull
-  Settings withSiteSettings(@NonNull Settings base,
-                            @NonNull Site site) {
+  Settings withSiteSettings(Settings base,
+                            Site site) {
     return Settings.builder()
       .source(base)
       .siteSource(site)
       .build();
   }
 
-  @NonNull
-  private GCExchangeFacade openSession(@NonNull Settings settings) {
+  private GCExchangeFacade openSession(Settings settings) {
     return openSession(settings.properties());
   }
 
   @VisibleForTesting
-  @NonNull
-  GCExchangeFacade openSession(@NonNull Map<String, Object> settings) {
+  GCExchangeFacade openSession(Map<String, Object> settings) {
     return defaultFactory().openSession(settings);
   }
 
@@ -615,9 +608,9 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
    * @param exception the exception to handle.
    * @param result    the execution result so far.
    */
-  private Result<R> getResultForCMSConnectionError(@NonNull Settings settings,
-                                                   @NonNull RuntimeException exception,
-                                                   @NonNull Result<R> result) {
+  private Result<R> getResultForCMSConnectionError(Settings settings,
+                                                   RuntimeException exception,
+                                                   Result<R> result) {
     // if exception is not indicating a curable CMS connection error situation, re-throw it without configuring a retry
     if (!isRepositoryUnavailableException(exception)) {
       throw exception;
@@ -701,7 +694,6 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
     return getConnection().getBlobService().fromBytes(bytes, MIME_TYPE_JSON);
   }
 
-  @NonNull
   @VisibleForTesting
   static String issuesAsJsonString(Map<Severity, Map<String, List<Content>>> issues) {
     Type typeToken = new TypeToken<Map<Severity, Map<XliffImportResultCode, List<Content>>>>() {
@@ -711,7 +703,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
 
   private static class ContentObjectSerializer implements JsonSerializer<ContentObject> {
     @Override
-    public JsonElement serialize(ContentObject contentObject, Type type, JsonSerializationContext jsonSerializationContext) {
+    public JsonElement serialize(@Nullable ContentObject contentObject, Type type, JsonSerializationContext jsonSerializationContext) {
       if (contentObject == null) {
         return JsonNull.INSTANCE;
       }
@@ -721,7 +713,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
 
   @VisibleForTesting
   record Parameters<P>(@Nullable P extendedParameters,
-                       @NonNull Collection<ContentObject> masterContentObjects,
+                       Collection<ContentObject> masterContentObjects,
                        int remainingAutomaticRetries) {
   }
 
@@ -735,6 +727,7 @@ abstract class GlobalLinkAction<P, R> extends SpringAwareLongAction {
     /**
      * JSON with a map from studio severity to a map of error codes to possibly empty list of affected contents
      */
+    @Nullable
     Blob issues;
     /**
      * Number of remaining automatic retries, if there are issues.

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkWorkflowErrorCodes.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkWorkflowErrorCodes.java
@@ -1,9 +1,8 @@
 package com.coremedia.labs.translation.gcc.workflow;
 
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 final class GlobalLinkWorkflowErrorCodes {
 
   // ==== 10###: General/Unknown Problems

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkAction.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkAction.java
@@ -14,7 +14,8 @@ import com.coremedia.labs.translation.gcc.facade.GCFacadeCommunicationException;
 import com.coremedia.translate.item.ContentToTranslateItemTransformer;
 import com.coremedia.translate.item.TranslateItem;
 import com.google.common.collect.ImmutableMap;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.FileSystemResource;
@@ -42,12 +43,14 @@ import static com.coremedia.cap.translate.xliff.XliffExportOptions.xliffExportOp
 import static com.coremedia.labs.translation.gcc.workflow.GlobalLinkWorkflowErrorCodes.XLIFF_EXPORT_FAILURE;
 import static com.coremedia.translate.item.TransformStrategy.ITEM_PER_TARGET;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
 
 /**
  * Requests a translation from GlobalLink by opening a submission with uploaded XLIFF for translatable
  * properties of content specified by the workflow.
  */
+@NullMarked
 public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAction.Parameters, String> {
   private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
 
@@ -56,12 +59,12 @@ public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAct
 
   private static final String GCC_RETRY_DELAY_SETTINGS_KEY = "sendTranslationRequestRetryDelay";
 
-  private String derivedContentsVariable;
-  private String subjectVariable;
-  private String commentVariable;
-  private String performerVariable;
-  private String globalLinkDueDateVariable;
-  private String globalLinkWorkflowVariable;
+  private @Nullable String derivedContentsVariable;
+  private @Nullable String subjectVariable;
+  private @Nullable String commentVariable;
+  private @Nullable String performerVariable;
+  private @Nullable String globalLinkDueDateVariable;
+  private @Nullable String globalLinkWorkflowVariable;
 
   // --- construct and configure ----------------------------------------------------------------------
 
@@ -139,14 +142,12 @@ public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAct
   // --- GlobalLinkAction interface ----------------------------------------------------------------------
 
   @Override
-  @NonNull
   protected String getGCCRetryDelaySettingsKey() {
     return GCC_RETRY_DELAY_SETTINGS_KEY;
   }
 
   @SuppressWarnings("UseOfObsoleteDateTimeApi")
   @Override
-  @NonNull
   Parameters doExtractParameters(Task task) {
     Process process = task.getContainingProcess();
 
@@ -176,8 +177,9 @@ public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAct
    *               these issues to the end-user, who may trigger a retry, for example.
    */
   @Override
-  void doExecuteGlobalLinkAction(Parameters params, Consumer<? super String> resultConsumer,
+  void doExecuteGlobalLinkAction(@Nullable Parameters params, Consumer<? super String> resultConsumer,
                                    GCExchangeFacade facade, Map<String, List<Content>> issues) {
+    requireNonNull(params, "Parameters must not be null.");
     Collection<Content> derivedContents = params.derivedContents;
     Collection<ContentObject> masterContentObjects = params.masterContentObjects;
     if (derivedContents.isEmpty() || masterContentObjects.isEmpty()) {
@@ -260,10 +262,10 @@ public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAct
    * @return the result that contains the ID of the created submission, or an error result
    * @throws GCFacadeCommunicationException if submitting the submission failed
    */
-  protected String submitSubmission(GCExchangeFacade facade, String subject, String comment,
-                                  Locale sourceLocale,
-                                  Map<Locale, List<TranslateItem>> translationItemsByLocale,
-                                  ZonedDateTime dueDate, String workflow, String submitter) {
+  protected String submitSubmission(GCExchangeFacade facade, String subject, @Nullable String comment,
+                                    Locale sourceLocale,
+                                    Map<Locale, List<TranslateItem>> translationItemsByLocale,
+                                    ZonedDateTime dueDate, @Nullable String workflow, @Nullable String submitter) {
 
     Map<String, List<Locale>> xliffFileIds = uploadContents(facade, sourceLocale, translationItemsByLocale);
 
@@ -310,9 +312,9 @@ public class SendToGlobalLinkAction extends GlobalLinkAction<SendToGlobalLinkAct
     return site.getLocale();
   }
 
-  record Parameters(String subject, String comment, Collection<Content> derivedContents,
-                    Collection<ContentObject> masterContentObjects, ZonedDateTime dueDate, String workflow,
-                    User submitter) {
+  record Parameters(String subject, @Nullable String comment, Collection<Content> derivedContents,
+                    Collection<ContentObject> masterContentObjects, ZonedDateTime dueDate, @Nullable String workflow,
+                    @Nullable User submitter) {
   }
 
 }

--- a/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/TranslateGccAutoConfiguration.java
+++ b/apps/workflow-server/gcc-workflow-server/src/main/java/com/coremedia/labs/translation/gcc/workflow/TranslateGccAutoConfiguration.java
@@ -5,8 +5,7 @@ import com.coremedia.cap.translate.xliff.config.XliffImporterConfiguration;
 import com.coremedia.translate.item.TranslateItemConfiguration;
 import com.coremedia.translate.workflow.DefaultTranslationWorkflowDerivedContentsStrategy;
 import com.coremedia.translate.workflow.TranslationWorkflowDerivedContentsStrategy;
-import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +21,7 @@ import java.util.Map;
         XliffExporterConfiguration.class,
         TranslateItemConfiguration.class})
 @PropertySource("classpath:META-INF/coremedia/gcc-workflow.properties")
-@DefaultAnnotation(NonNull.class)
+@NullMarked
 public class TranslateGccAutoConfiguration {
 
   /**
@@ -38,6 +37,7 @@ public class TranslateGccAutoConfiguration {
     return globalLinkTranslationWorkflowDerivedContentsStrategy;
   }
 
+  @SuppressWarnings("ConfigurationProperties")
   @ConfigurationProperties(prefix = "gcc")
   @Bean
   public Map<String, Object> gccConfigurationProperties() {

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/DownloadFromGlobalLinkActionUnitTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/DownloadFromGlobalLinkActionUnitTest.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -31,8 +31,9 @@ class DownloadFromGlobalLinkActionUnitTest {
   void setUp() {
     try {
       existingZipFile = Files.createTempFile("ccbwtgdfglaut", ".zip").toFile();
-      try (InputStream is = DownloadFromGlobalLinkActionUnitTest.class.getResourceAsStream("/com/coremedia/labs/translation/gcc/workflow/existing.zip");
-           OutputStream os = new FileOutputStream(existingZipFile)) {
+      InputStream is = requireNonNull(DownloadFromGlobalLinkActionUnitTest.class.getResourceAsStream("/com/coremedia/labs/translation/gcc/workflow/existing.zip"));
+      OutputStream os = new FileOutputStream(existingZipFile);
+      try (is; os) {
         IOUtils.copy(is, os);
       }
     } catch (IOException e) {
@@ -91,8 +92,8 @@ class DownloadFromGlobalLinkActionUnitTest {
           assertNotNull(files);
           assertEquals(2, files.length);
           // Check files by well known length, which is sufficiently unique in this test.
-          assertEquals(5L, Objects.requireNonNull(extracted.listFiles((dir, name) -> "zipentry2.txt".equals(name)))[0].length());
-          assertEquals(6L, Objects.requireNonNull(extracted.listFiles((dir, name) -> "zipentry3.txt".equals(name)))[0].length());
+          assertEquals(5L, requireNonNull(extracted.listFiles((dir, name) -> "zipentry2.txt".equals(name)))[0].length());
+          assertEquals(6L, requireNonNull(extracted.listFiles((dir, name) -> "zipentry3.txt".equals(name)))[0].length());
         } finally {
           deleteFile(extracted);
         }

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkActionTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkActionTest.java
@@ -143,7 +143,7 @@ class GlobalLinkActionTest {
             throw new IllegalStateException("Unknown retry delay source %s".formatted(retryDelaySource));
         }
 
-        GlobalLinkAction.Parameters<Object> params =
+        GlobalLinkAction.Parameters<@Nullable Object> params =
           new GlobalLinkAction.Parameters<>(
             null,
             List.of(masterSite.getSiteIndicator()),
@@ -190,7 +190,7 @@ class GlobalLinkActionTest {
 
         int remainingAutomaticRetries = 3;
 
-        GlobalLinkAction.Parameters<Object> params =
+        GlobalLinkAction.Parameters<@Nullable Object> params =
           new GlobalLinkAction.Parameters<>(
             null,
             List.of(masterSite.getSiteIndicator()),
@@ -230,7 +230,7 @@ class GlobalLinkActionTest {
           (rd, c) -> rd.saturatedAdapt(d -> d.dividedBy(delayDivisor))
         );
 
-        GlobalLinkAction.Parameters<Object> params =
+        GlobalLinkAction.Parameters<@Nullable Object> params =
           new GlobalLinkAction.Parameters<>(
             null,
             List.of(masterSite.getSiteIndicator()),

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkActionTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkActionTest.java
@@ -21,9 +21,9 @@ import com.coremedia.labs.translation.gcc.util.Settings;
 import com.coremedia.labs.translation.gcc.util.SettingsSource;
 import com.coremedia.rest.validation.Severity;
 import com.coremedia.springframework.xml.ResourceAwareXmlBeanDefinitionReader;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -69,20 +69,17 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 
 @SpringJUnitConfig(GlobalLinkActionTest.LocalConfig.class)
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+@NullMarked
 class GlobalLinkActionTest {
-  @NonNull
   private final MockedGlobalLinkAction globalLinkAction;
-  @NonNull
   private final ObjectProvider<Site> siteProvider;
-  @NonNull
   private final ObjectProvider<GlobalLinkConfigBuilder> globalLinkConfigBuilderProvider;
-  @NonNull
   private final ContentRepository repository;
 
-  GlobalLinkActionTest(@Autowired @NonNull MockedGlobalLinkAction globalLinkAction,
-                       @Autowired @NonNull ObjectProvider<Site> siteProvider,
-                       @Autowired @NonNull ObjectProvider<GlobalLinkConfigBuilder> globalLinkConfigBuilderProvider,
-                       @Autowired @NonNull ContentRepository repository) {
+  GlobalLinkActionTest(@Autowired MockedGlobalLinkAction globalLinkAction,
+                       @Autowired ObjectProvider<Site> siteProvider,
+                       @Autowired ObjectProvider<GlobalLinkConfigBuilder> globalLinkConfigBuilderProvider,
+                       @Autowired ContentRepository repository) {
     this.globalLinkAction = globalLinkAction;
     this.siteProvider = siteProvider;
     this.globalLinkConfigBuilderProvider = globalLinkConfigBuilderProvider;
@@ -120,7 +117,7 @@ class GlobalLinkActionTest {
         global
         site
         """)
-      void shouldAlwaysTriggerRetryOnTemporaryCmsOutages(@NonNull String retryDelaySource) {
+      void shouldAlwaysTriggerRetryOnTemporaryCmsOutages(String retryDelaySource) {
         int expectedRetryDelay;
 
         switch (retryDelaySource) {
@@ -174,10 +171,9 @@ class GlobalLinkActionTest {
     @ParameterizedClass
     @EnumSource(GlobalLinkConfigBuilder.RetryDelayMode.class)
     class RetryDelayBehavior {
-      @NonNull
       private final GlobalLinkConfigBuilder.RetryDelayMode retryDelayMode;
 
-      public RetryDelayBehavior(@NonNull GlobalLinkConfigBuilder.RetryDelayMode retryDelayMode) {
+      public RetryDelayBehavior(GlobalLinkConfigBuilder.RetryDelayMode retryDelayMode) {
         this.retryDelayMode = retryDelayMode;
       }
 
@@ -243,6 +239,7 @@ class GlobalLinkActionTest {
 
         GlobalLinkAction.Result<Void> result = globalLinkAction.doExecute(params);
 
+        assertThat(result).isNotNull();
         assertThat(result.retryDelaySeconds)
           .as("Should use expected adapted retry delay key (%d divided by %d)", retryDelayBase, delayDivisor)
           .isEqualTo(expectedRetryDelay.toSecondsInt());
@@ -286,7 +283,7 @@ class GlobalLinkActionTest {
   class IsRepositoryUnavailableExceptionBehavior {
     @ParameterizedTest
     @EnumSource(RepositoryUnavailableFixture.class)
-    void shouldSignalAMatchOnRepositoryNotAvailableVariant(@NonNull RepositoryUnavailableFixture fixture) {
+    void shouldSignalAMatchOnRepositoryNotAvailableVariant(RepositoryUnavailableFixture fixture) {
       Exception exception = fixture.exception();
       assertThat(GlobalLinkAction.isRepositoryUnavailableException(exception))
         .as("Should signal a match for: %s".formatted(exception))
@@ -295,7 +292,7 @@ class GlobalLinkActionTest {
 
     @ParameterizedTest
     @EnumSource(NoRepositoryUnavailableFixture.class)
-    void shouldSignalNoMatchOnIrrelevantException(@NonNull NoRepositoryUnavailableFixture fixture) {
+    void shouldSignalNoMatchOnIrrelevantException(NoRepositoryUnavailableFixture fixture) {
       Exception exception = fixture.exception();
       assertThat(GlobalLinkAction.isRepositoryUnavailableException(exception))
         .as("Should signal no match for: %s".formatted(exception))
@@ -330,23 +327,20 @@ class GlobalLinkActionTest {
      */
     CORBA_OBJECT_NOT_EXIST_ISSUE_EXCEPTION(new CapException("content", CapErrorCodes.UNEXPECTED_RUNTIME_EXCEPTION, null, new OBJECT_NOT_EXIST()));
 
-    @NonNull
     private final Exception exception;
 
-    RepositoryUnavailableFixture(@NonNull Function<RepositoryNotAvailableException, Exception> exceptionFunction) {
+    RepositoryUnavailableFixture(Function<RepositoryNotAvailableException, Exception> exceptionFunction) {
       exception = exceptionFunction.apply(createRepositoryNotAvailableException());
     }
 
-    RepositoryUnavailableFixture(@NonNull Exception exception) {
+    RepositoryUnavailableFixture(Exception exception) {
       this.exception = exception;
     }
 
-    @NonNull
     public Exception exception() {
       return exception;
     }
 
-    @NonNull
     public static RepositoryNotAvailableException createRepositoryNotAvailableException() {
       return new RepositoryNotAvailableException("foo", null, null);
     }
@@ -360,14 +354,12 @@ class GlobalLinkActionTest {
     CAP_EXCEPTION_WITH_IRRELEVANT_ERROR_CODE(new CapException("foo", CapErrorCodes.CANNOT_READ_BLOB, null, null)),
     ;
 
-    @NonNull
     private final Exception exception;
 
-    NoRepositoryUnavailableFixture(@NonNull Exception exception) {
+    NoRepositoryUnavailableFixture(Exception exception) {
       this.exception = exception;
     }
 
-    @NonNull
     public Exception exception() {
       return exception;
     }
@@ -384,7 +376,6 @@ class GlobalLinkActionTest {
     private static final long serialVersionUID = -288745610618179168L;
     private final ApplicationContext applicationContext;
     private final GCExchangeFacade gcExchangeFacade;
-    @NonNull
     private Runnable onDoExecuteGlobalLinkAction = () -> {
       // No operation.
     };
@@ -399,11 +390,11 @@ class GlobalLinkActionTest {
       this.gcExchangeFacade = gcExchangeFacade;
     }
 
-    public void onDoExecuteGlobalLinkAction(@NonNull Runnable onDoExecuteGlobalLinkAction) {
+    public void onDoExecuteGlobalLinkAction(Runnable onDoExecuteGlobalLinkAction) {
       this.onDoExecuteGlobalLinkAction = onDoExecuteGlobalLinkAction;
     }
 
-    public void adaptDelayForGeneralRetryBy(@NonNull BiFunction<? super RetryDelay, ? super AdaptDelayForGeneralRetryContext<Void, Void>, RetryDelay> retryDelayOperator) {
+    public void adaptDelayForGeneralRetryBy(BiFunction<? super RetryDelay, ? super AdaptDelayForGeneralRetryContext<Void, Void>, RetryDelay> retryDelayOperator) {
       this.retryDelayOperator = retryDelayOperator;
     }
 
@@ -414,41 +405,36 @@ class GlobalLinkActionTest {
     }
 
     @Override
-    void doExecuteGlobalLinkAction(Void params, Consumer<? super Void> resultConsumer,
+    void doExecuteGlobalLinkAction(@Nullable Void params, Consumer<? super Void> resultConsumer,
                                    GCExchangeFacade facade, Map<String, List<Content>> issues) {
       onDoExecuteGlobalLinkAction.run();
     }
 
     @Override
-    @NonNull
     protected ApplicationContext getSpringContext() {
       return applicationContext;
     }
 
-    @NonNull
     @Override
-    RetryDelay adaptDelayForGeneralRetry(@NonNull RetryDelay originalRetryDelay,
-                                         @NonNull AdaptDelayForGeneralRetryContext<Void, Void> context) {
+    RetryDelay adaptDelayForGeneralRetry(RetryDelay originalRetryDelay,
+                                         AdaptDelayForGeneralRetryContext<Void, Void> context) {
       if (retryDelayOperator == null) {
         return super.adaptDelayForGeneralRetry(originalRetryDelay, context);
       }
       return retryDelayOperator.apply(originalRetryDelay, context);
     }
 
-    @NonNull
     @Override
-    GCExchangeFacade openSession(@NonNull Map<String, Object> settings) {
+    GCExchangeFacade openSession(Map<String, Object> settings) {
       return gcExchangeFacade;
     }
 
-    @NonNull
-    GCExchangeFacade superOpenSession(@NonNull Map<String, Object> settings) {
+    GCExchangeFacade superOpenSession(Map<String, Object> settings) {
       return super.openSession(settings);
     }
 
-    @NonNull
     @Override
-    Settings withGlobalSettings(@NonNull Settings base, @NonNull ContentRepository repository) {
+    Settings withGlobalSettings(Settings base, ContentRepository repository) {
       Settings.Builder builder = Settings.builder().source(base);
       // Allow to also use our test-content-types.
       SettingsSource.allAt(
@@ -459,9 +445,8 @@ class GlobalLinkActionTest {
       return builder.build();
     }
 
-    @NonNull
     @Override
-    Settings withSiteSettings(@NonNull Settings base, @NonNull Site site) {
+    Settings withSiteSettings(Settings base, Site site) {
       Settings.Builder builder = Settings.builder().source(base);
       // Allow to also use our test-content-types.
       SettingsSource.allAt(
@@ -478,13 +463,9 @@ class GlobalLinkActionTest {
 
     @Override
     protected String getGCCRetryDelaySettingsKey() {
-      if (overrideGccRetryDelaySettingsKey == null) {
-        return super.getGCCRetryDelaySettingsKey();
-      }
-      return overrideGccRetryDelaySettingsKey;
+      return Objects.requireNonNullElseGet(overrideGccRetryDelaySettingsKey, super::getGCCRetryDelaySettingsKey);
     }
 
-    @Nullable
     @Override
     Blob issuesAsJsonBlob(Map<String, List<Content>> issues) {
       return Mockito.mock(Blob.class, "issuesAsJsonBlob(%d): %s".formatted(
@@ -510,9 +491,9 @@ class GlobalLinkActionTest {
   static class LocalConfig {
     @Scope(BeanDefinition.SCOPE_SINGLETON)
     @Bean
-    MockedGlobalLinkAction globalLinkAction(@NonNull ApplicationContext context,
-                                            @NonNull CapConnection connection,
-                                            @NonNull GCExchangeFacade gcExchangeFacade) {
+    MockedGlobalLinkAction globalLinkAction(ApplicationContext context,
+                                            CapConnection connection,
+                                            GCExchangeFacade gcExchangeFacade) {
       MockedGlobalLinkAction action = new MockedGlobalLinkAction(context, gcExchangeFacade);
       action.setConnection(connection);
       return action;
@@ -526,13 +507,13 @@ class GlobalLinkActionTest {
 
     @Bean
     @Scope(BeanDefinition.SCOPE_PROTOTYPE)
-    public GlobalLinkConfigBuilder globalLinkConfigBuilder(@NonNull CapConnection connection) {
+    public GlobalLinkConfigBuilder globalLinkConfigBuilder(CapConnection connection) {
       return new GlobalLinkConfigBuilder(connection.getContentRepository(), connection.getStructService());
     }
 
     @Bean
     @Scope(BeanDefinition.SCOPE_PROTOTYPE)
-    public Site site(@NonNull ContentRepository repository, @NonNull SitesService sitesService) {
+    public Site site(ContentRepository repository, SitesService sitesService) {
       String randomId = UUID.randomUUID().toString();
       repository.createContentBuilder()
         .type("SimpleSite")

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkConfigBuilder.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/GlobalLinkConfigBuilder.java
@@ -6,8 +6,8 @@ import com.coremedia.cap.struct.Struct;
 import com.coremedia.cap.struct.StructBuilder;
 import com.coremedia.cap.struct.StructService;
 import com.coremedia.labs.translation.gcc.util.Settings;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.format.annotation.DurationFormat;
 import org.springframework.format.datetime.standard.DurationFormatterUtils;
 
@@ -18,49 +18,42 @@ import java.util.Map;
 import static com.coremedia.labs.translation.gcc.workflow.SimpleMultiSiteConfiguration.CT_SITE_CONTENT;
 import static java.util.Objects.requireNonNull;
 
+@NullMarked
 public class GlobalLinkConfigBuilder {
   public static final String CT_GLOBAL_CONFIG = "SimpleStruct";
   public static final String P_GLOBAL_CONFIG = "value";
   public static final String CT_SITE_CONFIG = CT_SITE_CONTENT;
   public static final String P_SITE_CONFIG = "struct";
 
-  @NonNull
   private final StructService structService;
-  @NonNull
   private final ContentRepository repository;
-  @NonNull
   private RetryDelayMode retryDelayMode = RetryDelayMode.INTEGER;
   @Nullable
   private Site site;
-  @NonNull
   private final Map<String, Duration> retryDelays = new HashMap<>();
 
-  public GlobalLinkConfigBuilder(@NonNull ContentRepository repository,
-                                 @NonNull StructService structService) {
+  public GlobalLinkConfigBuilder(ContentRepository repository,
+                                 StructService structService) {
     this.structService = requireNonNull(structService);
     this.repository = requireNonNull(repository);
   }
 
-  @NonNull
   public GlobalLinkConfigBuilder atGlobal() {
     site = null;
     return this;
   }
 
-  @NonNull
-  public GlobalLinkConfigBuilder atSite(@NonNull Site site) {
+  public GlobalLinkConfigBuilder atSite(Site site) {
     this.site = requireNonNull(site);
     return this;
   }
 
-  @NonNull
-  public GlobalLinkConfigBuilder withRetryDelayMode(@NonNull RetryDelayMode retryDelayMode) {
+  public GlobalLinkConfigBuilder withRetryDelayMode(RetryDelayMode retryDelayMode) {
     this.retryDelayMode = requireNonNull(retryDelayMode);
     return this;
   }
 
-  @NonNull
-  public GlobalLinkConfigBuilder withRetryDelay(@NonNull String key, @NonNull Duration retryDelay) {
+  public GlobalLinkConfigBuilder withRetryDelay(String key, Duration retryDelay) {
     retryDelays.put(requireNonNull(key), requireNonNull(retryDelay));
     return this;
   }
@@ -68,9 +61,7 @@ public class GlobalLinkConfigBuilder {
   public void build() {
     StructBuilder configBuilder = structService.createStructBuilder()
       .enter("globalLink");
-    retryDelays.forEach((key, retryDelay) -> {
-      retryDelayMode.apply(configBuilder, key, retryDelay);
-    });
+    retryDelays.forEach((key, retryDelay) -> retryDelayMode.apply(configBuilder, key, retryDelay));
     Struct config = configBuilder.build();
     if (site == null) {
       repository.createContentBuilder()
@@ -93,26 +84,26 @@ public class GlobalLinkConfigBuilder {
   public enum RetryDelayMode {
     INTEGER {
       @Override
-      void apply(@NonNull StructBuilder structBuilder, @NonNull String key, @NonNull Duration duration) {
+      void apply(StructBuilder structBuilder, String key, Duration duration) {
         structBuilder
           .declareInteger(key, Math.toIntExact(duration.toSeconds()));
       }
     },
     INTEGER_AS_STRING {
       @Override
-      void apply(@NonNull StructBuilder structBuilder, @NonNull String key, @NonNull Duration duration) {
+      void apply(StructBuilder structBuilder, String key, Duration duration) {
         structBuilder
           .declareString(key, Integer.MAX_VALUE, Integer.toString(Math.toIntExact(duration.toSeconds())));
       }
     },
     DURATION_AS_STRING {
       @Override
-      void apply(@NonNull StructBuilder structBuilder, @NonNull String key, @NonNull Duration duration) {
+      void apply(StructBuilder structBuilder, String key, Duration duration) {
         structBuilder
           .declareString(key, Integer.MAX_VALUE, DurationFormatterUtils.print(duration, DurationFormat.Style.COMPOSITE));
       }
     };
 
-    abstract void apply(@NonNull StructBuilder structBuilder, @NonNull String key, @NonNull Duration duration);
+    abstract void apply(StructBuilder structBuilder, String key, Duration duration);
   }
 }

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkActionTest.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SendToGlobalLinkActionTest.java
@@ -12,8 +12,9 @@ import com.coremedia.labs.translation.gcc.facade.GCExchangeFacade;
 import com.coremedia.translate.item.TranslateItemConfiguration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.assertj.core.api.Condition;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.mockito.ArgumentCaptor;
@@ -64,6 +65,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
  */
 @SpringJUnitConfig(SendToGlobalLinkActionTest.LocalConfig.class)
 @DirtiesContext(classMode = AFTER_CLASS)
+@NullMarked
 class SendToGlobalLinkActionTest {
 
   @SuppressWarnings("unchecked")
@@ -96,7 +98,7 @@ class SendToGlobalLinkActionTest {
     targetContent.checkIn();
 
     String expectedFileId = targetContent.getId();
-    String[] uploadedXliff = {null};
+    @Nullable String[] uploadedXliff = {null};
 
     Mockito.doAnswer(invocation -> readXliff(invocation, expectedFileId, uploadedXliff))
             .when(gcExchangeFacade)
@@ -109,7 +111,7 @@ class SendToGlobalLinkActionTest {
     ZonedDateTime dueDate = ZonedDateTime.of(LocalDateTime.now().plusDays(30L), ZoneId.systemDefault());
     String workflow = "pseudo translation";
     SendToGlobalLinkAction.Parameters params = new SendToGlobalLinkAction.Parameters(displayName, comment, derivedContents, masterContents, dueDate, workflow, user);
-    AtomicReference<String> resultHolder = new AtomicReference<>();
+    AtomicReference<@Nullable String> resultHolder = new AtomicReference<>();
     action.doExecuteGlobalLinkAction(params, resultHolder::set, gcExchangeFacade, new HashMap<>());
     String submissionId = resultHolder.get();
 
@@ -140,7 +142,7 @@ class SendToGlobalLinkActionTest {
     assertThat(submitterCaptor.getValue()).isEqualTo("admin");
   }
 
-  private static Object readXliff(InvocationOnMock invocation, String expectedFileId, String[] uploadedXliff) throws IOException {
+  private static Object readXliff(InvocationOnMock invocation, String expectedFileId, @Nullable String[] uploadedXliff) throws IOException {
     Resource resource = invocation.getArgument(1);
     byte[] bytes;
     try (InputStream stream = resource.getInputStream()) {
@@ -183,7 +185,6 @@ class SendToGlobalLinkActionTest {
     }
 
     @Override
-    @NonNull
     protected ApplicationContext getSpringContext() {
       return applicationContext;
     }

--- a/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SimpleMultiSiteConfiguration.java
+++ b/apps/workflow-server/gcc-workflow-server/src/test/java/com/coremedia/labs/translation/gcc/workflow/SimpleMultiSiteConfiguration.java
@@ -8,7 +8,7 @@ import com.coremedia.cap.multisite.impl.MultiSiteConfiguration;
 import com.coremedia.cap.test.xmlrepo.XmlRepoConfiguration;
 import com.coremedia.cap.test.xmlrepo.XmlUapiConfig;
 import com.coremedia.translate.TranslatablePredicate;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -25,6 +25,7 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_SING
   XmlRepoConfiguration.class,
   MultiSiteConfiguration.class
 })
+@NullMarked
 public class SimpleMultiSiteConfiguration {
   /**
    * Content type recommended to be used within sites.
@@ -103,7 +104,7 @@ public class SimpleMultiSiteConfiguration {
 
   @Bean
   @Scope(SCOPE_SINGLETON)
-  public SiteModel siteModel(@NonNull ContentRepository contentRepository) {
+  public SiteModel siteModel(ContentRepository contentRepository) {
     DefaultSiteModel siteModel = new DefaultSiteModel();
 
     ContentType siteIndicatorType = requireNonNull(


### PR DESCRIPTION
Spring and many other third-party dependencies switch to [JSpecify](https://jspecify.dev/) meanwhile. This PR migrates all annotations to JSpecify, also fixing some possible nullability issues, detected while following the `null` rabbit into the rabbit hole.

This PR is based on #84 as it introduces a bunch of new classes and also more nullability hints. Thus, it should be merged after or into this branch.