### PR TITLE
Potential fix for code scanning alert no. 9: Code injection

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -40,6 +40,10 @@ jobs:
       build-ref: ${{ steps.check.outputs.build-ref }}
     steps:
       - id: check
+        env:
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           EVENT="${{ github.event_name }}"
           echo "Event: $EVENT"
@@ -56,9 +60,6 @@ jobs:
 
           # Only evaluate PR-specific data for pull_request events.
           if [[ "$EVENT" == "pull_request" ]]; then
-            PR_MERGED="${{ github.event.pull_request.merged }}"
-            HEAD_REF="${{ github.event.pull_request.head.ref }}"
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
             if [[ "$PR_MERGED" == "true" && "$HEAD_REF" =~ ^maintenance/ && "$BASE_REF" == "main" ]]; then
               echo "Merged maintenance/* PR into $BASE_REF: enabling deployment. (head: $HEAD_REF)"
               echo "should-deploy=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Potential fix for [https://github.com/CoreMedia/coremedia-globallink-connect-integration/security/code-scanning/9](https://github.com/CoreMedia/coremedia-globallink-connect-integration/security/code-scanning/9)

To fix this problem, we should never inject (via `${{ ... }}`) user-controlled inputs directly into shell script code in a `run` block. Instead, assign the expression to an environment variable using the `env:` key, and reference the environment variable (with `$HEAD_REF`, not `${{ ... }}`) within the shell script as needed. This ensures the shell receives the input as-is rather than parsing or interpreting it in the command.

**Detailed fix steps:**
- In the problematic step (with id `check`), move the assignments of `PR_MERGED`, `HEAD_REF`, and `BASE_REF` to the step's `env:` field.
- In the shell script (`run:` block), reference these variables via `$PR_MERGED`, `$HEAD_REF`, and `$BASE_REF` as shell variables.
- Remove the assignment lines inside the script that use GitHub Actions expressions `${{ ... }}`.
- No changes to later code are necessary, as all further uses already employ shell variables.

**Region to change:**  
- File: `.github/workflows/pages-deploy.yml`
- Step: `- id: check`
- Specifically, within the `run:` block of this step, and add/modify the `env:` element.

**What's needed:**
- No new methods or complex logic.
- Update/add `env:` to the step with `PR_MERGED`, `HEAD_REF`, and `BASE_REF`.
- Delete the three lines inside `run:` that assign these variables.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
