### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete string escaping or encoding

### DIFF
--- a/website/scripts/check-blocked-vulnerabilities.mjs
+++ b/website/scripts/check-blocked-vulnerabilities.mjs
@@ -73,7 +73,7 @@ function findInstalledVersions(lockContent, dependencyName) {
 }
 
 function parseBound(range, operator) {
-  const escapedOperator = operator.replace(/[<>=]/g, '\\$&')
+  const escapedOperator = escapeRegex(operator)
   const regex = new RegExp(`${escapedOperator}\\s*(\\d+\\.\\d+\\.\\d+)`)
   return range.match(regex)?.[1] || null
 }


### PR DESCRIPTION
Potential fix for [https://github.com/CoreMedia/coremedia-globallink-connect-integration/security/code-scanning/12](https://github.com/CoreMedia/coremedia-globallink-connect-integration/security/code-scanning/12)

To fix this safely, avoid partial/manual escaping in `parseBound` and use full regex escaping for the dynamic fragment (`operator`) before interpolating it into `RegExp`.

Best single change without altering functionality:
- In `website/scripts/check-blocked-vulnerabilities.mjs`, update `parseBound` so `escapedOperator` is computed with the existing `escapeRegex(operator)` helper instead of `operator.replace(/[<>=]/g, '\\$&')`.
- No new imports or dependencies are needed, since `escapeRegex` is already defined in this file.

This preserves behavior for normal operators (`<`, `<=`, `>`, `>=`, `=`) while making regex construction robust for any unexpected characters, including backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
